### PR TITLE
Distributed read model updater

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -197,6 +197,7 @@ lazy val `application` = (project in file("payment-app/application"))
       Akka.clusterTyped,
       Akka.clusterTools,
       Akka.clusterSharding,
+      Akka.clusterShardingTyped,
       Akka.slf4j,
       Akka.persistenceQuery,
       AkkaPersistenceCassandra.akkaPersistenceCassandra,

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/ECPaymentIssuingServiceEvent.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/ECPaymentIssuingServiceEvent.scala
@@ -9,6 +9,7 @@ import jp.co.tis.lerna.payment.adapter.issuing.model.{
   IssuingServiceResponse,
 }
 import jp.co.tis.lerna.payment.adapter.util.exception.BusinessException
+import jp.co.tis.lerna.payment.adapter.wallet.CustomerId
 import jp.co.tis.lerna.payment.application.ecpayment.issuing.IssuingServicePayCredential
 import jp.co.tis.lerna.payment.application.readmodelupdater.salesdetail.model.{
   MultipleResultTransaction,
@@ -21,7 +22,9 @@ sealed trait ECPaymentIssuingServiceEvent
 sealed trait ECPaymentIssuingServiceSalesDetailDomainEvent
     extends SalesDetailDomainEvent
     with MultipleResultTransaction
-    with ECPaymentIssuingServiceEvent
+    with ECPaymentIssuingServiceEvent {
+  def customerId: CustomerId
+}
 
 final case class SettlementAccepted(requestInfo: Settle, systemTime: LocalDateTime)(implicit val traceId: TraceId)
     extends ECPaymentIssuingServiceEvent
@@ -46,7 +49,9 @@ final case class SettlementSuccessConfirmed(
 )(implicit
     val traceId: TraceId,
 ) extends ECPaymentIssuingServiceEvent
-    with ECPaymentIssuingServiceSalesDetailDomainEvent
+    with ECPaymentIssuingServiceSalesDetailDomainEvent {
+  override def customerId: CustomerId = requestInfo.customerId
+}
 
 // 決済要求前に失敗
 // 非同期処理対象外
@@ -66,7 +71,9 @@ final case class SettlementFailureConfirmed(
     systemDate: LocalDateTime,                            // システム日付
 )(implicit val traceId: TraceId)
     extends ECPaymentIssuingServiceEvent
-    with ECPaymentIssuingServiceSalesDetailDomainEvent
+    with ECPaymentIssuingServiceSalesDetailDomainEvent {
+  override def customerId: CustomerId = requestInfo.customerId
+}
 
 final case class CancelAccepted(
     requestInfo: Cancel,          // presentation -> actorのリクエスト
@@ -86,7 +93,9 @@ final case class CancelSuccessConfirmed(
     systemDateTime: LocalDateTime,                                      // システム日時、※決済取消要求時のシステム日時
 )(implicit val traceId: TraceId)
     extends ECPaymentIssuingServiceEvent
-    with ECPaymentIssuingServiceSalesDetailDomainEvent
+    with ECPaymentIssuingServiceSalesDetailDomainEvent {
+  override def customerId: CustomerId = requestInfo.customerId
+}
 
 final case class CancelAborted(
 )(implicit val traceId: TraceId)
@@ -104,4 +113,6 @@ final case class CancelFailureConfirmed(
     systemDateTime: LocalDateTime,                                      // システム日時、※決済取消要求時のシステム日時
 )(implicit val traceId: TraceId)
     extends ECPaymentIssuingServiceEvent
-    with ECPaymentIssuingServiceSalesDetailDomainEvent
+    with ECPaymentIssuingServiceSalesDetailDomainEvent {
+  override def customerId: CustomerId = requestInfo.customerId
+}

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/HasDomainEventTag.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/HasDomainEventTag.scala
@@ -5,6 +5,8 @@ trait HasDomainEventTag {
   def domainEventTagPrefix: String
 
   /** Read Model Updater を何並列で動かすか
+    * <p> ※ 基本的には一度動かしたら途中で変更しない。Shard数と同じようにクラスターノードの計画された最大数の10倍程度が推奨されている。<br>
+    * 参考: [[https://doc.akka.io/docs/akka-projection/current/running.html#tagging-events-in-eventsourcedbehavior Running a Projection • Akka Projection]]
     */
   def numberOfTags: Int
 

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/HasDomainEventTag.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/HasDomainEventTag.scala
@@ -1,5 +1,12 @@
 package jp.co.tis.lerna.payment.application.readmodelupdater
+import scala.collection.immutable
 
 trait HasDomainEventTag {
-  def domainEventTag: String
+  def domainEventTagPrefix: String
+
+  /** Read Model Updater を何並列で動かすか
+    */
+  def numberOfTags: Int
+
+  lazy val domainEventTags: immutable.Seq[String] = Vector.tabulate(numberOfTags)(i => s"$domainEventTagPrefix-$i")
 }

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/ReadModelUpdaterManager.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/ReadModelUpdaterManager.scala
@@ -12,7 +12,7 @@ import jp.co.tis.lerna.payment.readmodel.JDBCService
 import jp.co.tis.lerna.payment.utility.tenant.AppTenant
 import wvlet.airframe._
 
-class ReadModelUpdaterSingletonManager(
+class ReadModelUpdaterManager(
     classicSystem: ActorSystem,
     session: Session,
     jdbcService: JDBCService,
@@ -32,8 +32,8 @@ class ReadModelUpdaterSingletonManager(
         )
       }
 
-  /** ReadModelUpdater(Singleton) を起動する
-    * Singleton は Cluster内のどこかに起動し、その中で ReadModelUpdater(Stream)が run する
+  /** ReadModelUpdater を起動する
+    * ShardedDaemonProcess によって Cluster 内で tag をキーとして散実行される
     * すでに起動している状態で呼び出してもOK
     */
   def startReadModelUpdaters(): Unit = {

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/HasSalesDetailDomainEventTag.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/HasSalesDetailDomainEventTag.scala
@@ -5,5 +5,5 @@ import jp.co.tis.lerna.payment.application.readmodelupdater.HasDomainEventTag
 trait HasSalesDetailDomainEventTag extends HasDomainEventTag {
   val componentName: String = "SalesDetail"
   def categoryName: String
-  override def domainEventTag: String = categoryName + componentName
+  override def domainEventTagPrefix: String = categoryName + componentName
 }

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/eventhandler/ECPaymentIssuingServiceEventHandler.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/eventhandler/ECPaymentIssuingServiceEventHandler.scala
@@ -36,6 +36,8 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 object ECPaymentIssuingServiceEventHandler extends HasSalesDetailDomainEventTag {
   val categoryName: String = "ECHouseMoney"
+
+  override def numberOfTags: Int = 50
 }
 
 class ECPaymentIssuingServiceEventHandler(
@@ -49,6 +51,7 @@ class ECPaymentIssuingServiceEventHandler(
     with AppLogging {
 
   override def categoryName: String = ECPaymentIssuingServiceEventHandler.categoryName
+  override def numberOfTags: Int    = ECPaymentIssuingServiceEventHandler.numberOfTags
 
   import tables.profile.api._
 
@@ -415,5 +418,4 @@ class ECPaymentIssuingServiceEventHandler(
       logicalDeleteFlag = LogicalDeleteFlag.unDeleted,// 論理削除フラグ
     )
   }
-
 }

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/tagging/salesdetail/SalesDetailEventToTags.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/tagging/salesdetail/SalesDetailEventToTags.scala
@@ -8,8 +8,10 @@ import jp.co.tis.lerna.payment.application.readmodelupdater.tagging.EventToTags
   */
 object SalesDetailEventToTags extends EventToTags {
   override protected def mapping: PartialFunction[Any, Set[String]] = {
-    case _: ECPaymentIssuingServiceSalesDetailDomainEvent =>
-      Set(ECPaymentIssuingServiceEventHandler.domainEventTag)
-
+    case event: ECPaymentIssuingServiceSalesDetailDomainEvent =>
+      val tags        = ECPaymentIssuingServiceEventHandler.domainEventTags
+      val i           = math.abs(event.customerId.value.hashCode % tags.size)
+      val selectedTag = tags(i)
+      Set(selectedTag)
   }
 }

--- a/payment-app/entrypoint/src/main/scala/jp/co/tis/lerna/payment/entrypoint/PaymentApp.scala
+++ b/payment-app/entrypoint/src/main/scala/jp/co/tis/lerna/payment/entrypoint/PaymentApp.scala
@@ -13,7 +13,7 @@ import com.typesafe.config.Config
 import com.typesafe.sslconfig.ssl.SSLConfigFactory
 import javax.net.ssl.{ KeyManager, SSLContext, X509TrustManager }
 import jp.co.tis.lerna.payment.adapter.util.health.HealthCheckApplication
-import jp.co.tis.lerna.payment.application.readmodelupdater.ReadModelUpdaterSingletonManager
+import jp.co.tis.lerna.payment.application.readmodelupdater.ReadModelUpdaterManager
 import jp.co.tis.lerna.payment.presentation.RootRoute
 import jp.co.tis.lerna.payment.presentation.util.directives.rejection.AppRejectionHandler
 import jp.co.tis.lerna.payment.presentation.util.errorhandling.AppExceptionHandler
@@ -32,7 +32,7 @@ class PaymentApp(implicit
     rootRoute: RootRoute,
     metrics: Metrics,
     config: Config,
-    readModelUpdaterSingletonManager: ReadModelUpdaterSingletonManager,
+    readModelUpdaterManager: ReadModelUpdaterManager,
     healthCheck: HealthCheckApplication,
 ) extends AppExceptionHandler
     with AppRejectionHandler {
@@ -45,7 +45,7 @@ class PaymentApp(implicit
         SystemMetrics.startCollecting()
 
         if (!config.getBoolean("jp.co.tis.lerna.payment.rdbms-read-only")) {
-          readModelUpdaterSingletonManager.startReadModelUpdaters()
+          readModelUpdaterManager.startReadModelUpdaters()
         }
         val privateInternetInterface = config.getString("private-internet.http.interface")
         val privateInternetPort      = config.getInt("private-internet.http.port")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,18 +34,19 @@ object Dependencies {
   }
 
   object Akka {
-    val slf4j            = "com.typesafe.akka" %% "akka-slf4j"              % Versions.akka
-    val actor            = "com.typesafe.akka" %% "akka-actor"              % Versions.akka
-    val stream           = "com.typesafe.akka" %% "akka-stream"             % Versions.akka
-    val cluster          = "com.typesafe.akka" %% "akka-cluster"            % Versions.akka
-    val clusterTyped     = "com.typesafe.akka" %% "akka-cluster-typed"      % Versions.akka
-    val clusterTools     = "com.typesafe.akka" %% "akka-cluster-tools"      % Versions.akka
-    val clusterSharding  = "com.typesafe.akka" %% "akka-cluster-sharding"   % Versions.akka
-    val persistence      = "com.typesafe.akka" %% "akka-persistence"        % Versions.akka
-    val persistenceQuery = "com.typesafe.akka" %% "akka-persistence-query"  % Versions.akka
-    val testKit          = "com.typesafe.akka" %% "akka-testkit"            % Versions.akka
-    val streamTestKit    = "com.typesafe.akka" %% "akka-stream-testkit"     % Versions.akka
-    val multiNodeTestKit = "com.typesafe.akka" %% "akka-multi-node-testkit" % Versions.akka
+    val slf4j                = "com.typesafe.akka" %% "akka-slf4j"                  % Versions.akka
+    val actor                = "com.typesafe.akka" %% "akka-actor"                  % Versions.akka
+    val stream               = "com.typesafe.akka" %% "akka-stream"                 % Versions.akka
+    val cluster              = "com.typesafe.akka" %% "akka-cluster"                % Versions.akka
+    val clusterTyped         = "com.typesafe.akka" %% "akka-cluster-typed"          % Versions.akka
+    val clusterTools         = "com.typesafe.akka" %% "akka-cluster-tools"          % Versions.akka
+    val clusterSharding      = "com.typesafe.akka" %% "akka-cluster-sharding"       % Versions.akka
+    val clusterShardingTyped = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % Versions.akka
+    val persistence          = "com.typesafe.akka" %% "akka-persistence"            % Versions.akka
+    val persistenceQuery     = "com.typesafe.akka" %% "akka-persistence-query"      % Versions.akka
+    val testKit              = "com.typesafe.akka" %% "akka-testkit"                % Versions.akka
+    val streamTestKit        = "com.typesafe.akka" %% "akka-stream-testkit"         % Versions.akka
+    val multiNodeTestKit     = "com.typesafe.akka" %% "akka-multi-node-testkit"     % Versions.akka
   }
 
   object AkkaHttp {


### PR DESCRIPTION
read-side の更新がボトルネックになる問題に対処。




## 参考
- [Running with Sharded Daemon Process](https://doc.akka.io/docs/akka-projection/current/running.html#running-with-sharded-daemon-process)


## 意思決定
- 分散する単位はユーザー(CustomerId) ごと

## 動作確認
[distributed-read-model-updater-動作確認](https://github.com/lerna-stack/lerna-sample-payment-app/tree/distributed-read-model-updater-%E5%8B%95%E4%BD%9C%E7%A2%BA%E8%AA%8D) ブランチ

- [x] リクエスト(の CustomerId) ごと に異なる node で read-model の作成処理が行われていること
  - RDBのマスタデータを用意するのが手間だったため、tag 付け部分で乱数を使用し模擬した

### nodeごとの起動数
3 node で起動した場合
```sh
$ curl --silent \
> -w "\n" \
> http://127.0.0.1:9002/metrics/rmu/sales_detail/ec_house_money/number_of_singleton?tenant=example \
> http://127.0.0.2:9002/metrics/rmu/sales_detail/ec_house_money/number_of_singleton?tenant=example \
> http://127.0.0.3:9002/metrics/rmu/sales_detail/ec_house_money/number_of_singleton?tenant=example
17
17
16
```

### offset table
```
MariaDB [PAYMENTAPP]> select * from akka_projection_offset_store; select count(*) from SALES_DETAIL;
+-------------------------+----------------------------+--------------------------------------+----------+-----------+---------------+
| projection_name         | projection_key             | current_offset                       | manifest | mergeable | last_updated  |
+-------------------------+----------------------------+--------------------------------------+----------+-----------+---------------+
| ECHouseMoneySalesDetail | ECHouseMoneySalesDetail-1  | a6d33d70-83d0-11eb-8b02-9132e21a6406 | TBU      |         0 | 1615621777479 |
| ECHouseMoneySalesDetail | ECHouseMoneySalesDetail-11 | afbeb7c0-83d0-11eb-aec9-51ab4f2f24cf | TBU      |         0 | 1615621792099 |
| ECHouseMoneySalesDetail | ECHouseMoneySalesDetail-15 | b8299060-83d0-11eb-bbc9-61d92dcf27d3 | TBU      |         0 | 1615621805939 |
| ECHouseMoneySalesDetail | ECHouseMoneySalesDetail-28 | 9dec5700-83d0-11eb-bbc9-61d92dcf27d3 | TBU      |         0 | 1615621761387 |
| ECHouseMoneySalesDetail | ECHouseMoneySalesDetail-29 | a37a2760-83d0-11eb-aec9-51ab4f2f24cf | TBU      |         0 | 1615621771672 |
| ECHouseMoneySalesDetail | ECHouseMoneySalesDetail-33 | b40a4420-83d0-11eb-8b02-9132e21a6406 | TBU      |         0 | 1615621799605 |
| ECHouseMoneySalesDetail | ECHouseMoneySalesDetail-34 | 7cf4db30-83d0-11eb-8b02-9132e21a6406 | TBU      |         0 | 1615621706512 |
| ECHouseMoneySalesDetail | ECHouseMoneySalesDetail-39 | 84d85b60-83d0-11eb-bbc9-61d92dcf27d3 | TBU      |         0 | 1615621720305 |
| ECHouseMoneySalesDetail | ECHouseMoneySalesDetail-46 | ac175aa0-83d0-11eb-bbc9-61d92dcf27d3 | TBU      |         0 | 1615621785414 |
| ECHouseMoneySalesDetail | ECHouseMoneySalesDetail-47 | 8fcf0f00-83d0-11eb-8b02-9132e21a6406 | TBU      |         0 | 1615621738461 |
+-------------------------+----------------------------+--------------------------------------+----------+-----------+---------------+
10 rows in set (0.000 sec)
```