### PR TITLE
起動用shでRDBを複数テナントで共有している問題に対処

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Lernaを使って実装した「決済ゲートウェイ」アプリケーショ
 1. Mock server起動
     - `docker-compose up -d mock`
 1. MariaDB起動
-   - `docker-compose up -d mariadb`
+   - `docker-compose up -d mariadb mariadb2`
 1. コンパイル&テスト実行
    - `sbt clean test:compile test`
 1. アプリ起動

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
 
-  mariadb:
+  mariadb: &mariadb_base
     image: mariadb:10.5.5
     restart: always
     ports:
@@ -15,6 +15,11 @@ services:
       MYSQL_DATABASE: "PAYMENTAPP"
       MYSQL_USER: "paymentapp"
       MYSQL_PASSWORD: "password"
+
+  mariadb2:
+    <<: *mariadb_base
+    ports:
+      - "${MARIADB2_BIND_IP_PORT:-127.0.0.2:3306}:3306"
 
   cassandra:
     build:

--- a/start-app-1.sh
+++ b/start-app-1.sh
@@ -10,9 +10,10 @@ sbt \
 -Djp.co.tis.lerna.payment.server-mode=DEV \
 -Dlerna.util.encryption.base64-key=v5LCFG4V1CbJxxPg+WTd8w== \
 -Dlerna.util.encryption.base64-iv=46A7peszgqN3q/ww4k8lWg== \
--Djp.co.tis.lerna.payment.readmodel.rdbms.db.url=jdbc:mysql://127.0.0.1:3306/PAYMENTAPP \
--Djp.co.tis.lerna.payment.readmodel.rdbms.db.user=paymentapp \
--Djp.co.tis.lerna.payment.readmodel.rdbms.db.password=password \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.tenants.example.db.url=jdbc:mysql://127.0.0.1:3306/PAYMENTAPP \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.tenants.tenant-a.db.url=jdbc:mysql://127.0.0.2:3306/PAYMENTAPP \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.default.db.user=paymentapp \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.default.db.password=password \
 -Djp.co.tis.lerna.payment.gateway.issuing.default.base-url="http://127.0.0.1:8083" \
 -Djp.co.tis.lerna.payment.gateway.wallet-system.default.base-url="http://127.0.0.1:8083" \
 -Dkamon.system-metrics.host.sigar-native-folder=native/1 \

--- a/start-app-2.sh
+++ b/start-app-2.sh
@@ -10,9 +10,10 @@ sbt \
 -Djp.co.tis.lerna.payment.server-mode=DEV \
 -Dlerna.util.encryption.base64-key=v5LCFG4V1CbJxxPg+WTd8w== \
 -Dlerna.util.encryption.base64-iv=46A7peszgqN3q/ww4k8lWg== \
--Djp.co.tis.lerna.payment.readmodel.rdbms.db.url=jdbc:mysql://127.0.0.1:3306/PAYMENTAPP \
--Djp.co.tis.lerna.payment.readmodel.rdbms.db.user=paymentapp \
--Djp.co.tis.lerna.payment.readmodel.rdbms.db.password=password \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.tenants.example.db.url=jdbc:mysql://127.0.0.1:3306/PAYMENTAPP \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.tenants.tenant-a.db.url=jdbc:mysql://127.0.0.2:3306/PAYMENTAPP \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.default.db.user=paymentapp \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.default.db.password=password \
 -Djp.co.tis.lerna.payment.gateway.issuing.default.base-url="http://127.0.0.1:8083" \
 -Djp.co.tis.lerna.payment.gateway.wallet-system.default.base-url="http://127.0.0.1:8083" \
 -Dkamon.system-metrics.host.sigar-native-folder=native/2 \

--- a/start-app-3.sh
+++ b/start-app-3.sh
@@ -10,9 +10,10 @@ sbt \
 -Djp.co.tis.lerna.payment.server-mode=DEV \
 -Dlerna.util.encryption.base64-key=v5LCFG4V1CbJxxPg+WTd8w== \
 -Dlerna.util.encryption.base64-iv=46A7peszgqN3q/ww4k8lWg== \
--Djp.co.tis.lerna.payment.readmodel.rdbms.db.url=jdbc:mysql://127.0.0.1:3306/PAYMENTAPP \
--Djp.co.tis.lerna.payment.readmodel.rdbms.db.user=paymentapp \
--Djp.co.tis.lerna.payment.readmodel.rdbms.db.password=password \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.tenants.example.db.url=jdbc:mysql://127.0.0.1:3306/PAYMENTAPP \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.tenants.tenant-a.db.url=jdbc:mysql://127.0.0.2:3306/PAYMENTAPP \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.default.db.user=paymentapp \
+-Djp.co.tis.lerna.payment.readmodel.rdbms.default.db.password=password \
 -Djp.co.tis.lerna.payment.gateway.issuing.default.base-url="http://127.0.0.1:8083" \
 -Djp.co.tis.lerna.payment.gateway.wallet-system.default.base-url="http://127.0.0.1:8083" \
 -Dkamon.system-metrics.host.sigar-native-folder=native/3 \


### PR DESCRIPTION
テナント間でデータが混ざっていた。

- 2個目の tenant 用の mariadb を用意
  - database と user を分けるのは手間なため docker コンテナを増やした
- アプリ起動用shのRDB接続設定を修正
  - 設定キーが間違っていた
  - 複数テナントで共有していた
