### PR TITLE
managemant route で無駄なheader checkをしている問題を修正

### DIFF
--- a/payment-app/presentation/src/main/scala/jp/co/tis/lerna/payment/presentation/management/HealthRoute.scala
+++ b/payment-app/presentation/src/main/scala/jp/co/tis/lerna/payment/presentation/management/HealthRoute.scala
@@ -12,8 +12,8 @@ import scala.util.{ Failure, Success }
   * HAProxy と Keepalived から、アプリのプロセスが生きているかチェックするためのエンドポイント
   */
 class HealthRoute(healthCheck: HealthCheckApplication) extends GenAppRequestContextDirective {
-  def route: Route = extractAppRequestContext { implicit appRequestContext =>
-    pathPrefix("health") {
+  def route: Route = pathPrefix("health") {
+    extractAppRequestContext { implicit appRequestContext =>
       onComplete(healthCheck.healthy()) {
         case Success(_) =>
           complete(StatusCodes.OK -> "OK")


### PR DESCRIPTION
HealthRoute(managemant) で path チェックより先に header チェックがされていたため、別の route でも WARNログが出ていた

> INFO    jp.co.tis.lerna.payment.presentation.management.HealthRoute     -   --       -       HTTP Header "X-Tenant-Id" が存在しません。Header を付与してください。
> WARN    jp.co.tis.lerna.payment.entrypoint.PaymentApp   -       -       -   -rejection: MissingHeaderRejection(X-Tenant-Id)