### PR TITLE
デフォルトだと Read Model Updater が初回Eventを処理するまで時間がかかる問題を修正

### DIFF
--- a/start-app-1.sh
+++ b/start-app-1.sh
@@ -3,7 +3,7 @@ set -ex
 
 sbt \
 -Dfork=true \
--Djp.co.tis.lerna.payment.application.persistence.cassandra.default.events-by-tag.first-time-bucket="20191030T10:30" \
+-Djp.co.tis.lerna.payment.application.persistence.cassandra.default.events-by-tag.first-time-bucket="$(date '+%Y%m%dT%H:%M' --utc)" \
 -Dakka.cluster.min-nr-of-members=2 \
 -Dakka.cluster.seed-nodes.0="akka://GatewaySystem@127.0.0.1:25520" \
 -Dakka.cluster.seed-nodes.1="akka://GatewaySystem@127.0.0.2:25520" \

--- a/start-app-2.sh
+++ b/start-app-2.sh
@@ -3,7 +3,7 @@ set -ex
 
 sbt \
 -Dfork=true \
--Djp.co.tis.lerna.payment.application.persistence.cassandra.default.events-by-tag.first-time-bucket="20191030T10:30" \
+-Djp.co.tis.lerna.payment.application.persistence.cassandra.default.events-by-tag.first-time-bucket="$(date '+%Y%m%dT%H:%M' --utc)" \
 -Dakka.cluster.min-nr-of-members=2 \
 -Dakka.cluster.seed-nodes.0="akka://GatewaySystem@127.0.0.1:25520" \
 -Dakka.cluster.seed-nodes.1="akka://GatewaySystem@127.0.0.2:25520" \

--- a/start-app-3.sh
+++ b/start-app-3.sh
@@ -3,7 +3,7 @@ set -ex
 
 sbt \
 -Dfork=true \
--Djp.co.tis.lerna.payment.application.persistence.cassandra.default.events-by-tag.first-time-bucket="20191030T10:30" \
+-Djp.co.tis.lerna.payment.application.persistence.cassandra.default.events-by-tag.first-time-bucket="$(date '+%Y%m%dT%H:%M' --utc)" \
 -Dakka.cluster.min-nr-of-members=2 \
 -Dakka.cluster.seed-nodes.0="akka://GatewaySystem@127.0.0.1:25520" \
 -Dakka.cluster.seed-nodes.1="akka://GatewaySystem@127.0.0.2:25520" \


### PR DESCRIPTION
前回の処理済offset情報がない場合、2019/10/30 から全Eventを検索していたため。
起動時刻から検索するように変更。