### PR TITLE
 cassandra container の healthcheck が unhealty になる問題を修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       MAX_HEAP_SIZE: ${CASSANDRA_MAX_HEAP_SIZE:-256M}
       HEAP_NEWSIZE: ${CASSANDRA_HEAP_NEWSIZE:-128M}
     healthcheck:
-      test: ["CMD", "cqlsh", "-e", "describe keyspaces"]
+      test: ["CMD", "cqlsh", "-e", "describe keyspaces", "-u", "cassandra", "-p", "cassandra"]
       interval: 3s
       timeout: 2s
       retries: 60


### PR DESCRIPTION
ログイン必須にしたが、ヘルスチェックで認証情報を指定してなかったため

## 対応前
```
$ docker-compose ps cassandra
                Name                              Command                   State                                     Ports
---------------------------------------------------------------------------------------------------------------------------------------------------------
lerna-sample-payment-app_cassandra_1   docker-entrypoint.sh cassa ...   Up (unhealthy)   7000/tcp, 7001/tcp, 7199/tcp, 127.0.0.1:9042->9042/tcp, 9160/tcp
```

## 対応後
```
$ docker-compose ps cassandra
                Name                              Command                  State                                    Ports
-------------------------------------------------------------------------------------------------------------------------------------------------------
lerna-sample-payment-app_cassandra_1   docker-entrypoint.sh cassa ...   Up (healthy)   7000/tcp, 7001/tcp, 7199/tcp, 127.0.0.1:9042->9042/tcp, 9160/tcp
```