### PR TITLE
Reconcile to be able to deploy using lerna-terraform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -104,7 +104,6 @@ lazy val `payment-app` = (project in file("."))
     bashScriptExtraDefines ++= Seq(
       s"""addJava "-Djp.co.tis.lerna.payment.presentation.versions.version=${version.value}"""",
       s"""addJava "-Djp.co.tis.lerna.payment.presentation.versions.commit-hash=${fetchGitCommitHash.value}"""",
-      s"""addJava "-Dakka.cluster.downing-provider-class=com.lightbend.akka.sbr.SplitBrainResolverProvider"""",
     ),
     maintainerScripts in Rpm ++= {
       import RpmConstants._

--- a/build.sbt
+++ b/build.sbt
@@ -91,6 +91,10 @@ lazy val `payment-app` = (project in file("."))
         packageMapping(
           (baseDirectory.value / "CHANGELOG.md") -> (defaultLinuxInstallLocation.value + s"/${name.value}" + "/CHANGELOG.md"),
         ),
+        // lerna-terraform でモックサーバを起動するために使用する
+        packageDirectoryAndContentsMapping(
+          (baseDirectory.value / "docker/mock-server") -> (defaultLinuxInstallLocation.value + s"/${name.value}" + "/docker/mock-server"),
+        ),
         // Kamon が起動時に /apl/${name}/native/libsigar-amd64-linux.so を書き込む
         packageTemplateMapping(
           defaultLinuxInstallLocation.value + s"/${name.value}" + "/native",


### PR DESCRIPTION
## Goal

Be able to deploy using [lerna-terraform](https://github.com/lerna-stack/lerna-terraform/).

## Changes
- Remove a property override that refers to the old SBR FQCN
- Add files of *mock-server* to an RPM file
  These files will be used by *lerna-terraform*.

## Related PR
- [デフォルトアプリケーションとして lerna-sample-payment-app をサポートする](https://github.com/lerna-stack/lerna-terraform/pull/5)