### PR TITLE
refactor: typed 対応のため sendToSelf の 処理を変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ TODO: sample の version 体系について検討
         - `/metrics/system-metrics/jvm-memory/heap/max`
 - `Scala 2.12.13` に更新しました
 - `sbt-wartremover 2.4.13` に更新しました
+- Akka typed 対応のため、 `PaymentActor` から `self` にメッセージを送る際の処理を変更しました
+    - graceful shutdown 時のレイテンシが増加する可能性があります
 
 ## Version 1.1.0
 - `Changed` Read Model Updater を分散実行しスループットを向上

--- a/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/PaymentActorSpec.scala
+++ b/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/PaymentActorSpec.scala
@@ -370,11 +370,7 @@ class PaymentActorSpec
                 dateTime,
                 transactionIdFactory,
                 paymentIdFactory,
-              ) {
-                override def sendToSelf(message: InnerCommand): Unit = {
-                  AtLeastOnceDelivery.tellTo(self, message)
-                }
-              },
+              ),
             ),
             name = MultiTenantShardingSupportTestHelper.generateActorName(),
           )
@@ -848,11 +844,7 @@ class PaymentActorSpec
           dateTime,
           transactionIdFactory,
           paymentIdFactory,
-        ) {
-          override def sendToSelf(message: InnerCommand): Unit = {
-            AtLeastOnceDelivery.tellTo(self, message)
-          }
-        },
+        ),
       ),
       name = MultiTenantShardingSupportTestHelper.generateActorName(),
     )


### PR DESCRIPTION
Graceful Shutdown 中の処理でメッセージロストが発生しないようにするための仕組みを変更


typed Cluster Sharding は ShardRegionProxy を明示して作成する機能がなくなっているため。

到達保証を使う場合、

* HTTP Server -> Actor 部分には AtLeastOnceDelivery を使用する
* Actor -> Actor 部分には使用せず、直接 `self` に投げる
* 必要に応じて 処理中は StopMessage を stash  して仕掛中の Future の処理を完了させてから Entity を落とすようにすると、処理結果が失われない
  * ※ graceful shutdownは遅くなる。graceful shutdown時に ShardRegion の stop, Shard の移動が終わらないと、該当Shardで処理されるリクエストのレイテンシが増加する

※ classicでは 従来の ShardRegionProxy 経由の到達保証も使用可能

⚠️ Rolling Update で Messageが unhandled になる可能性あり