### PR TITLE
chore: docker-compose up 時にデフォルトで sbt-rpmbuild を作成しないように変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       - "${MOCK_SERVER_IP_PORT:-127.0.0.1:8083}:3000"
 
   sbt-rpmbuild:
+    profiles:
+      - build
     build:
       context: docker/sbt-rpmbuild
       args:


### PR DESCRIPTION
通常使用しないものなのに、build/runされるのは面倒なため

docker-compose prifiles を使用

Compose でのプロファイル利用 | Docker ドキュメント
https://matsuand.github.io/docs.docker.jp.onthefly/compose/profiles/