### PR TITLE
sbt-wartremover 2.4.13 に更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ payment-app に関する注目すべき変更はこのファイルで文書化�
 
 TODO: sample の version 体系について検討
 
+### CHANGED
+- `sbt-wartremover 2.4.13` に更新します
+
 ## Version 1.1.0
 - `Changed` Read Model Updater を分散実行しスループットを向上
     - ※ tag の形式と offset の 保存テーブルが変更になったため、切替前後のeventの処理に注意（切替前のEventに未処理が存在する場合、切替後の処理対象とならない）

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
 addSbtPlugin("org.duhemm" % "sbt-errors-summary" % "0.6.3")
 
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.10")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover-contrib" % "1.3.1")
 


### PR DESCRIPTION
- `lerna-app-library v2.0.0+` で使用されます。
- Scala 2.12.12 と Scala 2.13.4 の両方で動作します。
