### PR TITLE
Scala 2.12.13 に更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ payment-app に関する注目すべき変更はこのファイルで文書化�
 TODO: sample の version 体系について検討
 
 ### CHANGED
+- `Scala 2.12.13` に更新します
 - `sbt-wartremover 2.4.13` に更新します
 
 ## Version 1.1.0

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val `payment-app` = (project in file("."))
       List(
         organization := "jp.co.tis.lerna.payment",
         version := "1.1.0",
-        scalaVersion := "2.12.12",
+        scalaVersion := "2.12.13",
         scalacOptions ++= Seq(
           "-deprecation",
           "-feature",


### PR DESCRIPTION
リリースノートは次の URL から確認できます。
[Release Scala 2.12.13 · scala/scala](https://github.com/scala/scala/releases/tag/v2.12.13)

次のリリースまでに `scala2.13.4` に更新予定だと思いますが、
`nowarn` を使用する必要がありそうなため、一度 `scala 2.12.13` に更新します。