### PR TITLE
lerna-app-library/scala test を更新

### DIFF
--- a/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/IssuingServiceGatewayECPaymentApplicationSpec.scala
+++ b/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/IssuingServiceGatewayECPaymentApplicationSpec.scala
@@ -23,10 +23,12 @@ import lerna.util.tenant.Tenant
 import lerna.util.trace.TraceId
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{ Seconds, Span }
-import org.scalatest.{ Inside, MustMatchers, WordSpecLike }
+import org.scalatest.Inside
 import wvlet.airframe.Design
 
 import scala.concurrent.Future
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 object IssuingServiceGatewayECPaymentApplicationSpec {
   private val issuingService = new IssuingServiceGateway {
@@ -60,8 +62,8 @@ object IssuingServiceGatewayECPaymentApplicationSpec {
 )
 class IssuingServiceGatewayECPaymentApplicationSpec
     extends StandardSpec
-    with WordSpecLike
-    with MustMatchers
+    with AnyWordSpecLike
+    with Matchers
     with DISessionSupport
     with JDBCSupport
     with Inside

--- a/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/PaymentActorSpec.scala
+++ b/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/PaymentActorSpec.scala
@@ -25,10 +25,12 @@ import lerna.util.tenant.Tenant
 import lerna.util.time.{ FixedLocalDateTimeFactory, LocalDateTimeFactory }
 import lerna.util.trace.TraceId
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{ Inside, MustMatchers, WordSpecLike }
+import org.scalatest.Inside
 import wvlet.airframe.Design
 
 import scala.concurrent.Future
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 // Lint回避のため
 @SuppressWarnings(
@@ -43,8 +45,8 @@ import scala.concurrent.Future
 class PaymentActorSpec
     extends TestKit(ActorSystem("PaymentActorSpec"))
     with ImplicitSender
-    with WordSpecLike
-    with MustMatchers
+    with AnyWordSpecLike
+    with Matchers
     with DISessionSupport
     with JDBCSupport
     with Inside

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/IssuingServiceGatewayPaymentCancelSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/IssuingServiceGatewayPaymentCancelSpec.scala
@@ -23,10 +23,12 @@ import jp.co.tis.lerna.payment.utility.tenant.Example
 import jp.co.tis.lerna.payment.utility.{ AppRequestContext, UtilityDIDesign }
 import lerna.testkit.airframe.DISessionSupport
 import lerna.util.trace.TraceId
-import org.scalatest.{ Inside, Matchers, WordSpec }
+import org.scalatest.Inside
 import wvlet.airframe.Design
 
 import scala.concurrent.Future
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 object IssuingServiceGatewayPaymentCancelSpec {
   private val issuingServiceECPaymentApplication = new IssuingServiceECPaymentApplication {
@@ -75,7 +77,7 @@ object IssuingServiceGatewayPaymentCancelSpec {
   ),
 )
 class IssuingServiceGatewayPaymentCancelSpec
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ScalatestRouteTest
     with ValidationJsonSupport

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/IssuingServiceGatewayPaymentSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/IssuingServiceGatewayPaymentSpec.scala
@@ -23,10 +23,12 @@ import jp.co.tis.lerna.payment.utility.tenant.Example
 import jp.co.tis.lerna.payment.utility.{ AppRequestContext, UtilityDIDesign }
 import lerna.testkit.airframe.DISessionSupport
 import lerna.util.trace.TraceId
-import org.scalatest.{ Inside, Matchers, WordSpec }
+import org.scalatest.Inside
 import wvlet.airframe.Design
 
 import scala.concurrent.Future
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 object IssuingServiceGatewayPaymentSpec {
   private val issuingServiceECPaymentApplication = new IssuingServiceECPaymentApplication {
@@ -75,7 +77,7 @@ object IssuingServiceGatewayPaymentSpec {
   ),
 )
 class IssuingServiceGatewayPaymentSpec
-    extends WordSpec
+    extends AnyWordSpec
     with Matchers
     with ScalatestRouteTest
     with ValidationJsonSupport

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/management/HealthRouteSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/management/HealthRouteSpec.scala
@@ -12,10 +12,11 @@ import jp.co.tis.lerna.payment.presentation.util.directives.GenTenantDirective
 import jp.co.tis.lerna.payment.utility.scalatest.StandardSpec
 import jp.co.tis.lerna.payment.utility.tenant.{ AppTenant, Example }
 import lerna.testkit.airframe.DISessionSupport
-import org.scalatest.{ Inside, WordSpec }
+import org.scalatest.Inside
 import wvlet.airframe.Design
 
 import scala.concurrent.Future
+import org.scalatest.wordspec.AnyWordSpec
 
 @SuppressWarnings(
   Array(
@@ -23,7 +24,7 @@ import scala.concurrent.Future
     "org.wartremover.warts.Equals",
   ),
 )
-class HealthRouteSpec extends WordSpec with StandardSpec with ScalatestRouteTest with Inside with DISessionSupport {
+class HealthRouteSpec extends AnyWordSpec with StandardSpec with ScalatestRouteTest with Inside with DISessionSupport {
 
   override protected val diDesign: Design = PresentationDIDesign.presentationDesign
     .bind[ActorSystem].toInstance(system)

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/management/MetricsRouteSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/management/MetricsRouteSpec.scala
@@ -9,8 +9,9 @@ import jp.co.tis.lerna.payment.presentation.management.mock.MetricsImplMock
 import jp.co.tis.lerna.payment.utility.scalatest.StandardSpec
 import lerna.management.stats.Metrics
 import lerna.testkit.airframe.DISessionSupport
-import org.scalatest.{ Inside, WordSpec }
+import org.scalatest.Inside
 import wvlet.airframe.Design
+import org.scalatest.wordspec.AnyWordSpec
 
 @SuppressWarnings(
   Array(
@@ -20,7 +21,7 @@ import wvlet.airframe.Design
     "org.wartremover.warts.Throw",
   ),
 )
-class MetricsRouteSpec extends WordSpec with StandardSpec with ScalatestRouteTest with Inside with DISessionSupport {
+class MetricsRouteSpec extends AnyWordSpec with StandardSpec with ScalatestRouteTest with Inside with DISessionSupport {
 
   override protected val diDesign: Design = PresentationDIDesign.presentationDesign
     .bind[ActorSystem].toProvider { config: Config =>

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/management/ShutdownSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/management/ShutdownSpec.scala
@@ -9,10 +9,11 @@ import jp.co.tis.lerna.payment.adapter.util.shutdown.GracefulShutdownApplication
 import jp.co.tis.lerna.payment.utility.scalatest.StandardSpec
 import jp.co.tis.lerna.payment.utility.tenant.AppTenant
 import lerna.testkit.airframe.DISessionSupport
-import org.scalatest.{ Inside, WordSpec }
+import org.scalatest.Inside
 import wvlet.airframe.{ newDesign, Design }
 
 import scala.concurrent.Future
+import org.scalatest.wordspec.AnyWordSpec
 
 object ShutdownSpec {
   private class HealthCheckApplicationMock extends HealthCheckApplication {
@@ -47,7 +48,7 @@ object ShutdownSpec {
     "org.wartremover.warts.Equals",
   ),
 )
-class ShutdownSpec extends WordSpec with StandardSpec with ScalatestRouteTest with Inside with DISessionSupport {
+class ShutdownSpec extends AnyWordSpec with StandardSpec with ScalatestRouteTest with Inside with DISessionSupport {
 
   import ShutdownSpec._
 

--- a/payment-app/testkit/src/main/scala/jp/co/tis/lerna/payment/utility/scalatest/StandardSpec.scala
+++ b/payment-app/testkit/src/main/scala/jp/co/tis/lerna/payment/utility/scalatest/StandardSpec.scala
@@ -1,6 +1,7 @@
 package jp.co.tis.lerna.payment.utility.scalatest
 
-import org.scalatest.{ MustMatchers, WordSpecLike }
 import lerna.util.lang.Equals
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
-trait StandardSpec extends WordSpecLike with SpecAssertions with Equals with MustMatchers
+trait StandardSpec extends AnyWordSpecLike with SpecAssertions with Equals with Matchers

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val lerna                    = "2.0.0-6bad8983-SNAPSHOT"
+    val lerna                    = "2.0.0-92f060be-SNAPSHOT"
     val akka                     = "2.6.10"
     val akkaHttp                 = "10.1.12"
     val akkaPersistenceCassandra = "1.0.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
     val akkaHttp                 = "10.1.12"
     val akkaPersistenceCassandra = "1.0.1"
     val akkaProjection           = "1.1.0"
-    val scalaTest                = "3.0.9"
+    val scalaTest                = "3.1.4"
     val airframe                 = "20.9.0"
     val logback                  = "1.2.3"
     val slick                    = "3.3.2"


### PR DESCRIPTION
## 更新
- lerna-app-library `2.0.0-92f060be-SNAPSHOT`
  - ScalaTest v3.1.4 対応
  - lerna-util-akka typed 対応
- ScalaTest to `3.1.4`

