### PR TITLE
update Scala to 2.13.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -216,6 +216,10 @@ lazy val `read-model` = (project in file("payment-app/read-model"))
       Slick.hikaricp,
       MariaDB.connectorJ,
     ),
+    scalacOptions ++= Seq(
+      // 自動生成コードの警告を無視
+      "-Wconf:cat=lint-multiarg-infix&src=scala/jp/co/tis/lerna/payment/readmodel/schema/Tables.scala:silent",
+    ),
   )
 
 lazy val `utility` = (project in file("payment-app/utility"))

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val `payment-app` = (project in file("."))
       List(
         organization := "jp.co.tis.lerna.payment",
         version := "1.1.0",
-        scalaVersion := "2.12.13",
+        scalaVersion := "2.13.6",
         scalacOptions ++= Seq(
           "-deprecation",
           "-feature",

--- a/payment-app/adapter/src/main/scala/jp/co/tis/lerna/payment/adapter/ecpayment/issuing/model/PaymentCancelParameter.scala
+++ b/payment-app/adapter/src/main/scala/jp/co/tis/lerna/payment/adapter/ecpayment/issuing/model/PaymentCancelParameter.scala
@@ -2,8 +2,6 @@ package jp.co.tis.lerna.payment.adapter.ecpayment.issuing.model
 
 import jp.co.tis.lerna.payment.adapter.ecpayment.model.{ OrderId, WalletShopId }
 import jp.co.tis.lerna.payment.adapter.wallet.{ ClientId, CustomerId }
-import jp.co.tis.lerna.payment.adapter.ecpayment.model.{ OrderId, WalletShopId }
-import jp.co.tis.lerna.payment.adapter.wallet.{ ClientId, CustomerId }
 
 // Presentation -> Application パラメータ引き渡す用
 final case class PaymentCancelParameter(

--- a/payment-app/adapter/src/main/scala/jp/co/tis/lerna/payment/adapter/ecpayment/issuing/model/PaymentId.scala
+++ b/payment-app/adapter/src/main/scala/jp/co/tis/lerna/payment/adapter/ecpayment/issuing/model/PaymentId.scala
@@ -8,7 +8,7 @@ sealed abstract case class PaymentId(value: String) {
 }
 
 object PaymentId {
-  def apply(value: BigInt): PaymentId = new PaymentId("%05d".format(value.longValue())) {}
+  def apply(value: BigInt): PaymentId = new PaymentId("%05d".format(value.longValue)) {}
 
   val maxSequence: BigInt = BigInt("99999")
 }

--- a/payment-app/adapter/src/main/scala/jp/co/tis/lerna/payment/adapter/ecpayment/issuing/model/PaymentParameter.scala
+++ b/payment-app/adapter/src/main/scala/jp/co/tis/lerna/payment/adapter/ecpayment/issuing/model/PaymentParameter.scala
@@ -2,8 +2,6 @@ package jp.co.tis.lerna.payment.adapter.ecpayment.issuing.model
 
 import jp.co.tis.lerna.payment.adapter.ecpayment.model.{ OrderId, WalletShopId }
 import jp.co.tis.lerna.payment.adapter.wallet.{ ClientId, CustomerId }
-import jp.co.tis.lerna.payment.adapter.ecpayment.model.{ OrderId, WalletShopId }
-import jp.co.tis.lerna.payment.adapter.wallet.{ ClientId, CustomerId }
 
 // Presentation -> Application パラメータ引き渡す用
 final case class PaymentParameter(

--- a/payment-app/adapter/src/main/scala/jp/co/tis/lerna/payment/adapter/ecpayment/issuing/model/TransactionId.scala
+++ b/payment-app/adapter/src/main/scala/jp/co/tis/lerna/payment/adapter/ecpayment/issuing/model/TransactionId.scala
@@ -8,7 +8,7 @@ sealed abstract case class TransactionId(value: String) {
 }
 
 object TransactionId {
-  def apply(value: BigInt): TransactionId = new TransactionId("%012d".format(value.longValue())) {}
+  def apply(value: BigInt): TransactionId = new TransactionId("%012d".format(value.longValue)) {}
 
   val maxSequence: BigInt = BigInt("999999999999")
 }

--- a/payment-app/adapter/src/main/scala/jp/co/tis/lerna/payment/adapter/wallet/CustomerId.scala
+++ b/payment-app/adapter/src/main/scala/jp/co/tis/lerna/payment/adapter/wallet/CustomerId.scala
@@ -1,7 +1,6 @@
 package jp.co.tis.lerna.payment.adapter.wallet
 
 import jp.co.tis.lerna.payment.adapter.util.authorization.model.Subject
-import jp.co.tis.lerna.payment.adapter.util.authorization.model.Subject
 
 final case class CustomerId(value: String) extends AnyVal
 

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/PaymentActor.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/PaymentActor.scala
@@ -343,7 +343,7 @@ object PaymentActor extends AppTypedActorLogging {
 
       for {
         payCredential <- fetchPayCredential(customerId, payRequest.clientId, payRequest.walletShopId)
-        transactionId <- setup.transactionIdFactory.generate
+        transactionId <- setup.transactionIdFactory.generate()
         paymentId     <- setup.paymentIdFactory.generateIdFor(customerId)
         request = {
           setup.logger.debug("walletId:" + payCredential.walletId.toString)
@@ -623,7 +623,7 @@ object PaymentActor extends AppTypedActorLogging {
           issuingServiceCancel.walletShopId,
         )
         paymentId     <- setup.paymentIdFactory.generateIdFor(customerId)
-        transactionId <- setup.transactionIdFactory.generate
+        transactionId <- setup.transactionIdFactory.generate()
         acquirerReversalRequestParameter = AcquirerReversalRequestParameter(
           transactionId = transactionId,        // 取引ID、採番
           paymentId = paymentId,                // (会員ごと)決済番号

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/PaymentActor.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/PaymentActor.scala
@@ -150,7 +150,7 @@ object PaymentActor extends AppTypedActorLogging {
   }
 
   def entityId(clientId: ClientId, walletShopId: WalletShopId, orderId: OrderId): EntityId =
-    s"${clientId.value}-${walletShopId.value}-${orderId.value}"
+    s"${clientId.value.toString}-${walletShopId.value}-${orderId.value}"
 
   object Sharding {
 
@@ -294,7 +294,7 @@ object PaymentActor extends AppTypedActorLogging {
 
       case payRequest: Settle =>
         import payRequest.appRequestContext
-        setup.logger.debug(s"IssuingService : $payRequest")
+        setup.logger.debug(s"IssuingService : ${payRequest.toString}")
 
         // リクエスト直前の時刻をこちらで作成（変数化）
         val systemTime = setup.dateTimeFactory.now()
@@ -420,7 +420,7 @@ object PaymentActor extends AppTypedActorLogging {
       case StopActor =>
         implicit def tenant: AppTenant = setup.tenant // `import setup.tenant` だと型推論がうまく動かないため def で型を明示
         import lerna.util.tenant.TenantComponentLogContext.logContext
-        setup.logger.info(s"[state: $this, receive: StopActor] 処理結果待ちのため終了処理を保留します")
+        setup.logger.info(s"[state: ${this.toString}, receive: StopActor] 処理結果待ちのため終了処理を保留します")
         Effect.stash()
 
       case paymentResult: SettlementResult =>
@@ -436,7 +436,7 @@ object PaymentActor extends AppTypedActorLogging {
                   case `errCodeOk` =>
                     val res = SettlementSuccessResponse()
                     setup.logger.debug(
-                      s"status ok: paymentProcessing, systemTime: $systemTime ",
+                      s"status ok: paymentProcessing, systemTime: ${systemTime.toString} ",
                     )
 
                     val event =
@@ -708,7 +708,7 @@ object PaymentActor extends AppTypedActorLogging {
       case StopActor =>
         implicit def tenant: AppTenant = setup.tenant // `import setup.tenant` だと型推論がうまく動かないため def で型を明示
         import lerna.util.tenant.TenantComponentLogContext.logContext
-        setup.logger.info(s"[state: $this, receive: StopActor] 処理結果待ちのため終了処理を保留します")
+        setup.logger.info(s"[state: ${this.toString}, receive: StopActor] 処理結果待ちのため終了処理を保留します")
         Effect.stash()
 
       case `processingTimeoutMessage` =>
@@ -892,7 +892,7 @@ object PaymentActor extends AppTypedActorLogging {
         setup.logger.info("すでに処理済みのため、前回の処理結果を返します(前回とキーが同じリクエストが来ました)")
 
         setup.logger.info(
-          s"status: failed, msg: $msg",
+          s"status: failed, msg: ${msg.toString}",
         )
         stopSelfSafely()
         Effect.reply(msg.replyTo)(SettlementFailureResponse(message))

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/HasDomainEventTag.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/HasDomainEventTag.scala
@@ -10,5 +10,6 @@ trait HasDomainEventTag {
     */
   def numberOfTags: Int
 
-  lazy val domainEventTags: immutable.Seq[String] = Vector.tabulate(numberOfTags)(i => s"$domainEventTagPrefix-$i")
+  lazy val domainEventTags: immutable.Seq[String] =
+    Vector.tabulate(numberOfTags)(i => s"$domainEventTagPrefix-${i.toString}")
 }

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/SalesDetailEventHandler.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/SalesDetailEventHandler.scala
@@ -87,8 +87,8 @@ trait SalesDetailEventHandler[E <: SalesDetailDomainEvent]
     timestampOption.foreach { timestamp =>
       val nowTimestamp = System.currentTimeMillis()
       val delay: Long  = nowTimestamp - timestamp
-      logger.debug(s"Cassandra書き込み時間: $timestamp , RDB書き込み時間: $nowTimestamp")
-      logger.debug(s"RDBへの書き込み遅延時間: $delay ms")
+      logger.debug(s"Cassandra書き込み時間: ${timestamp.toString} , RDB書き込み時間: ${nowTimestamp.toString}")
+      logger.debug(s"RDBへの書き込み遅延時間: ${delay.toString} ms")
       updateDelayHistogram.record(delay)
     }
   }

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/eventhandler/ECPaymentIssuingServiceEventHandler.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/eventhandler/ECPaymentIssuingServiceEventHandler.scala
@@ -123,8 +123,8 @@ class ECPaymentIssuingServiceEventHandler(
       case Some(throwable) =>
         val message = s"""ReadModelの更新に失敗しました。
                          |persistenceId: ${envelope.persistenceId},
-                         |sequenceNr: ${envelope.sequenceNr},
-                         |event: ${envelope.event}
+                         |sequenceNr: ${envelope.sequenceNr.toString},
+                         |event: ${envelope.event.toString}
                          |""".stripMargin
         logger.error(throwable, message)
     }
@@ -331,7 +331,7 @@ class ECPaymentIssuingServiceEventHandler(
           // 2件以上（履歴不備）
           // ※ 必ず1件になるように運用する
           logger.error(
-            s"SalesDetail.eventPersistenceId === $eventPersistenceId & saleCancelType === 売上(01) の取得結果が ${results.length} 件です。",
+            s"SalesDetail.eventPersistenceId === $eventPersistenceId & saleCancelType === 売上(01) の取得結果が ${results.length.toString} 件です。",
           )
           None
       }

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/eventhandler/ECPaymentIssuingServiceEventHandler.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/eventhandler/ECPaymentIssuingServiceEventHandler.scala
@@ -278,7 +278,7 @@ class ECPaymentIssuingServiceEventHandler(
           walletId = payCredential.walletId,
           customerNumber = payCredential.customerNumber,
           intranid = payResponse.map(_.intranid),
-          originDealId = event.right.map(_.paymentResponse.intranid).toOption,
+          originDealId = event.map(_.paymentResponse.intranid).toOption,
           contractNumber = payCredential.contractNumber,
           pan = payCredential.housePan,
           saleDatetime = Timestamp.valueOf(event.fold(_.systemDate, _.saleDateTime)), // 買上日時
@@ -293,7 +293,7 @@ class ECPaymentIssuingServiceEventHandler(
           errorCode = getError(payResponse.map(_.rErrcode)),
           transactionId = transactionId,
           paymentId = paymentId,
-          originalPaymentId = event.right.map(_.originalRequest.paymentId).toOption,
+          originalPaymentId = event.map(_.originalRequest.paymentId).toOption,
           cashBackTempAmount = None,
           isApplicationExtractable = false,
           customerId = event.fold(_.requestInfo.customerId, _.requestInfo.customerId),

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/tagging/TaggingEventAdapter.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/readmodelupdater/tagging/TaggingEventAdapter.scala
@@ -3,7 +3,6 @@ package jp.co.tis.lerna.payment.application.readmodelupdater.tagging
 import akka.actor.ExtendedActorSystem
 import akka.persistence.journal.{ Tagged, WriteEventAdapter }
 import jp.co.tis.lerna.payment.application.readmodelupdater.tagging.salesdetail.SalesDetailEventToTags
-import jp.co.tis.lerna.payment.application.readmodelupdater.tagging.salesdetail.SalesDetailEventToTags
 
 class TaggingEventAdapter(system: ExtendedActorSystem) extends WriteEventAdapter {
   override def manifest(event: Any): String = "" // when no manifest needed, return ""

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/util/health/HealthCheckApplicationImpl.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/util/health/HealthCheckApplicationImpl.scala
@@ -31,7 +31,7 @@ object HealthCheckApplicationImpl {
       def eventSourcedBehavior(): EventSourcedBehavior[TestPersistentActor.Ping, NotUsed, NotUsed] =
         EventSourcedBehavior
           .withEnforcedReplies[TestPersistentActor.Ping, NotUsed, NotUsed](
-            persistenceId = PersistenceId.ofUniqueId(s"dummy-${UUID.randomUUID()}"),
+            persistenceId = PersistenceId.ofUniqueId(s"dummy-${UUID.randomUUID().toString}"),
             emptyState = NotUsed,
             commandHandler = { case (_, ping) => Effect.stop().thenReply(ping.replyTo)(_ => Done) },
             eventHandler = { case (state, _) => state },
@@ -162,7 +162,7 @@ class HealthCheckApplicationImpl(config: Config, tables: Tables, system: ActorSy
         if (result) {
           Done
         } else {
-          throw new IllegalStateException(s"Illegal result: $result")
+          throw new IllegalStateException(s"Illegal result: ${result.toString}")
         }
       }.recover {
         case exception: Exception =>
@@ -184,7 +184,7 @@ class HealthCheckApplicationImpl(config: Config, tables: Tables, system: ActorSy
             val finiteDuration =
               config.getDuration("jp.co.tis.lerna.payment.application.util.health.wait-for-detaching").asScala
 
-            logger.info(s"終了処理のため、ヘルスチェック停止後、切り離されるまで $finiteDuration 待ちます")
+            logger.info(s"終了処理のため、ヘルスチェック停止後、切り離されるまで ${finiteDuration.toString} 待ちます")
             Thread.sleep(finiteDuration.toMillis)
 
             Done

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/util/shutdown/GracefulShutdownApplicationImpl.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/util/shutdown/GracefulShutdownApplicationImpl.scala
@@ -16,7 +16,7 @@ class GracefulShutdownApplicationImpl(
 
     val shardRegionTypeNameSet = clusterSharding.shardTypeNames
 
-    logger.info(s"ShardRegion の GracefulShutdown を開始します(対象: $shardRegionTypeNameSet)")
+    logger.info(s"ShardRegion の GracefulShutdown を開始します(対象: ${shardRegionTypeNameSet.toString})")
 
     for (typeName <- shardRegionTypeNameSet) {
       val shardRegion = clusterSharding.shardRegion(typeName)

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantShardingSupport.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantShardingSupport.scala
@@ -39,7 +39,9 @@ object MultiTenantShardingSupport {
       s"The entityId must be able to be split in exactly 2 with the delimiter [${delimiter.toString}]",
     )
 
-    val Array(encodedTenantId, encodedOriginalEntityId) = entityId.split(delimiter)
+    val (encodedTenantId, encodedOriginalEntityId) = (entityId.split(delimiter): @unchecked) match {
+      case Array(_1, _2) => (_1, _2) // `match may not be exhaustive.` 警告対策
+    }
 
     val tenant           = AppTenant.withId(decode(encodedTenantId))
     val originalEntityId = decode(encodedOriginalEntityId)

--- a/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantShardingSupport.scala
+++ b/payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantShardingSupport.scala
@@ -19,7 +19,10 @@ object MultiTenantShardingSupport {
 
   private[this] def encode(str: String) = {
     val encodedString = URLEncoder.encode(str, StandardCharsets.UTF_8.name)
-    encodedString.ensuring(!_.contains(delimiter), s"encodedString should not contain delimiter [${delimiter}]")
+    encodedString.ensuring(
+      !_.contains(delimiter),
+      s"encodedString should not contain delimiter [${delimiter.toString}]",
+    )
   }
   private[this] def decode(str: String) = URLDecoder.decode(str, StandardCharsets.UTF_8.name)
 
@@ -27,13 +30,13 @@ object MultiTenantShardingSupport {
     val encodedTenantId         = encode(tenant.id)
     val encodedOriginalEntityId = encode(entityId)
 
-    s"${encodedTenantId}${delimiter}${encodedOriginalEntityId}"
+    s"${encodedTenantId}${delimiter.toString}${encodedOriginalEntityId}"
   }
 
   private[tenant] def extractTenantAndEntityId(entityId: String): (AppTenant, String) = {
     require(
       entityId.count(_ === delimiter) === 1,
-      s"The entityId must be able to be split in exactly 2 with the delimiter [${delimiter}]",
+      s"The entityId must be able to be split in exactly 2 with the delimiter [${delimiter.toString}]",
     )
 
     val Array(encodedTenantId, encodedOriginalEntityId) = entityId.split(delimiter)

--- a/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/IssuingServiceGatewayECPaymentApplicationSpec.scala
+++ b/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/IssuingServiceGatewayECPaymentApplicationSpec.scala
@@ -117,12 +117,9 @@ class IssuingServiceGatewayECPaymentApplicationSpec
           ClientId(123),
         )
 
-      whenReady(application.pay(settlementConfirmResponse).failed, timeout(Span(10, Seconds))) {
-        case ex: RuntimeException =>
-          ex match {
-            case ex: BusinessException =>
-              expect { ex.message.messageId === "CODE-002" }
-          }
+      inside(application.pay(settlementConfirmResponse).failed.futureValue(timeout(Span(10, Seconds)))) {
+        case ex: BusinessException =>
+          expect { ex.message.messageId === "CODE-002" }
       }
     }
 
@@ -131,12 +128,9 @@ class IssuingServiceGatewayECPaymentApplicationSpec
       val paymentCancelParameter =
         PaymentCancelParameter(WalletShopId("456"), OrderId("456"), CustomerId("123"), ClientId(123))
 
-      whenReady(application.cancel(paymentCancelParameter).failed, timeout(Span(10, Seconds))) {
-        case ex: RuntimeException =>
-          ex match {
-            case ex: BusinessException =>
-              expect { ex.message.messageId === "CODE-002" }
-          }
+      inside(application.cancel(paymentCancelParameter).failed.futureValue(timeout(Span(10, Seconds)))) {
+        case ex: BusinessException =>
+          expect { ex.message.messageId === "CODE-002" }
       }
       system.terminate()
     }

--- a/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/TransactionIdFactoryImplSpec.scala
+++ b/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/TransactionIdFactoryImplSpec.scala
@@ -40,7 +40,7 @@ class TransactionIdFactoryImplSpec extends ScalaTestWithTypedActorTestKit() with
   "TransactionIdFactory" when {
     "正常系 12桁の数字が取得できる" in {
       val transactionIdFactory = diSession.build[TransactionIdFactory]
-      whenReady(transactionIdFactory.generate) { r =>
+      whenReady(transactionIdFactory.generate()) { r =>
         expect { r === TransactionId(1) }
       }
     }

--- a/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/eventhandler/ECPaymentIssuingServiceEventHandlerSpec.scala
+++ b/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/readmodelupdater/salesdetail/eventhandler/ECPaymentIssuingServiceEventHandlerSpec.scala
@@ -98,15 +98,15 @@ class ECPaymentIssuingServiceEventHandlerSpec
     amountTran = AmountTran(generateUniqueNumber()),
     tranDateTime = LocalDateTime.of(2019, 12, 31, 12, 34, 56),
     transactionId = TransactionId(generateUniqueNumber()),
-    accptrId = s"${generateUniqueNumber()}",
+    accptrId = generateUniqueNumber().toString,
     paymentId = PaymentId(generateUniqueNumber()),
-    terminalId = TerminalId(s"${generateUniqueNumber()}"),
+    terminalId = TerminalId(generateUniqueNumber().toString),
   )
 
   val acquirerReversalRequestParameter = AcquirerReversalRequestParameter(
     transactionId = TransactionId(generateUniqueNumber()),
     paymentId = PaymentId(generateUniqueNumber()),
-    terminalId = TerminalId(s"${generateUniqueNumber()}"),
+    terminalId = TerminalId(generateUniqueNumber().toString),
   )
 
   val eventPersistenceId: String = "dummy-persistence-id"

--- a/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantShardingSupportSpec.scala
+++ b/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantShardingSupportSpec.scala
@@ -7,10 +7,11 @@ import org.scalatest.BeforeAndAfterAll
 class MultiTenantShardingSupportSpec extends StandardSpec with BeforeAndAfterAll {
 
   import jp.co.tis.lerna.payment.application.util.tenant.actor.MultiTenantShardingSupport.{
-    delimiter,
     extractTenantAndEntityId,
     tenantSupportEntityId,
   }
+
+  private val delimiter = MultiTenantShardingSupport.delimiter.toString
 
   "tenantSupportEntityId() & extractTenantAndEntityId()" when {
     "すべてのテナントで" should {

--- a/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantShardingSupportTestHelper.scala
+++ b/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantShardingSupportTestHelper.scala
@@ -5,7 +5,7 @@ import jp.co.tis.lerna.payment.utility.tenant.AppTenant
 
 object MultiTenantShardingSupportTestHelper {
   def generateEntityId()(implicit tenant: AppTenant): EntityId = {
-    MultiTenantShardingSupport.tenantSupportEntityId(s"${generateUniqueNumber()}")
+    MultiTenantShardingSupport.tenantSupportEntityId(s"${generateUniqueNumber().toString}")
   }
 
   private[this] val generateUniqueNumber: () => Int = {

--- a/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantShardingSupportTestHelper.scala
+++ b/payment-app/application/src/test/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantShardingSupportTestHelper.scala
@@ -3,13 +3,15 @@ package jp.co.tis.lerna.payment.application.util.tenant.actor
 import akka.cluster.sharding.ShardRegion.EntityId
 import jp.co.tis.lerna.payment.utility.tenant.AppTenant
 
+import java.util.concurrent.atomic.AtomicInteger
+
 object MultiTenantShardingSupportTestHelper {
   def generateEntityId()(implicit tenant: AppTenant): EntityId = {
     MultiTenantShardingSupport.tenantSupportEntityId(s"${generateUniqueNumber().toString}")
   }
 
   private[this] val generateUniqueNumber: () => Int = {
-    val iterator = Stream.from(0).iterator
-    () => iterator.next()
+    val counter = new AtomicInteger(0)
+    () => counter.incrementAndGet()
   }
 }

--- a/payment-app/entrypoint/src/main/scala/jp/co/tis/lerna/payment/entrypoint/PaymentApp.scala
+++ b/payment-app/entrypoint/src/main/scala/jp/co/tis/lerna/payment/entrypoint/PaymentApp.scala
@@ -64,7 +64,7 @@ class PaymentApp(implicit
     val coordinatedShutdown = CoordinatedShutdown(actorSystem)
 
     coordinatedShutdown.addTask(CoordinatedShutdown.PhaseServiceUnbind, s"http-unbind-$typeName") { () =>
-      logger.info(s"[$typeName] 終了処理のため、$serverBinding をunbindします")
+      logger.info(s"[$typeName] 終了処理のため、${serverBinding.toString} をunbindします")
 
       serverBinding.unbind().map(_ => Done)
     }
@@ -74,10 +74,12 @@ class PaymentApp(implicit
         val hardDeadline =
           config.getDuration("jp.co.tis.lerna.payment.entrypoint.graceful-termination.hard-deadline").asScala
 
-        logger.info(s"[$typeName] 終了処理のため、$serverBinding の graceful terminate を開始します（最大で $hardDeadline 待ちます）")
+        logger.info(
+          s"[$typeName] 終了処理のため、${serverBinding.toString} の graceful terminate を開始します（最大で ${hardDeadline.toString} 待ちます）",
+        )
 
         serverBinding.terminate(hardDeadline) map { _ =>
-          logger.info(s"[$typeName] 終了処理のための $serverBinding の graceful terminate が終了しました")
+          logger.info(s"[$typeName] 終了処理のための ${serverBinding.toString} の graceful terminate が終了しました")
 
           Done
         }

--- a/payment-app/gateway/src/main/scala/jp/co/tis/lerna/payment/gateway/issuing/IssuingServiceGatewayImpl.scala
+++ b/payment-app/gateway/src/main/scala/jp/co/tis/lerna/payment/gateway/issuing/IssuingServiceGatewayImpl.scala
@@ -148,14 +148,16 @@ class IssuingServiceGatewayImpl(config: Config)(implicit val system: ActorSystem
           httpResponse.discardEntityBytes()
           val message: SystemFailureMessage = IssuingServiceUnavailable(request.mti.name)
           logger.warn(s"${message.messageId}: ${message.messageContent}")
-          logger.warn(s"Issuing Service からのレスポンスのStatusCodes が ServerError(${httpResponse.status}) のため障害取消します")
+          logger.warn(
+            s"Issuing Service からのレスポンスのStatusCodes が ServerError(${httpResponse.status.toString()}) のため障害取消します",
+          )
           Future.successful(Left(message))
 
         // 上記以外の場合、ワーニングログを出力して「(6) 決済履歴一時登録」処理へ。
         case _ =>
           httpResponse.discardEntityBytes()
           val message: SystemFailureMessage = IssuingServiceServerError(request.mti.name)
-          logger.warn(s"${message.messageId}: ${message.messageContent} ${httpResponse.status}")
+          logger.warn(s"${message.messageId}: ${message.messageContent} ${httpResponse.status.toString()}")
           Future.successful(Left(message))
       }
 
@@ -259,14 +261,14 @@ class IssuingServiceGatewayImpl(config: Config)(implicit val system: ActorSystem
         case _: StatusCodes.ServerError => //500～599
           val message = IssuingServiceUnavailable(transNmFailureCancel)
           logger.warn(s"${message.messageId}: ${message.messageContent}")
-          logger.warn(s"Issuing Service からのレスポンスのStatusCodes が ServerError(${httpResponse.status})")
+          logger.warn(s"Issuing Service からのレスポンスのStatusCodes が ServerError(${httpResponse.status.toString()})")
           throw new BusinessException(message)
 
         // 上記以外の場合、ワーニングログを出力して「(6) 決済履歴一時登録」処理へ。
         case _ =>
           val message: SystemFailureMessage = IssuingServiceServerError(transNmFailureCancel)
           logger.warn(s"${message.messageId}: ${message.messageContent}")
-          logger.warn(s"障害取消に失敗しました(StatusCode == ${httpResponse.status})")
+          logger.warn(s"障害取消に失敗しました(StatusCode == ${httpResponse.status.toString()})")
           message
       }
     }

--- a/payment-app/gateway/src/main/scala/jp/co/tis/lerna/payment/gateway/notification/HouseMoneySettlementNotificationImpl.scala
+++ b/payment-app/gateway/src/main/scala/jp/co/tis/lerna/payment/gateway/notification/HouseMoneySettlementNotificationImpl.scala
@@ -73,6 +73,7 @@ final case class HouseMoneySettlementNotificationImpl(rootConfig: Config, implic
           case StatusCodes.BadRequest =>
             Unmarshal(response.entity).to[NotificationErrorResponse].map { res =>
               logger.error(s"response Status Code: ${response.status.value}, code: ${res.errors
+                .map(_.map(_.code).toString())
                 .getOrElse(Errors("", "", "empty errors").code)}, message: ${res.message.getOrElse("empty message")}")
 
               val message = PayCompleteNotifyBadRequest("ハウスマネー決済完通知API呼び出し", res.message.getOrElse("-"))

--- a/payment-app/gateway/src/test/scala/jp/co/tis/lerna/payment/gateway/issuing/IssuingServiceGatewaySpec.scala
+++ b/payment-app/gateway/src/test/scala/jp/co/tis/lerna/payment/gateway/issuing/IssuingServiceGatewaySpec.scala
@@ -92,7 +92,7 @@ class IssuingServiceGatewaySpec
         IssuingServiceMock.`IS:承認売上要求／承認取消要求でBadRequestを返す`,
       )
 
-      whenReady(gateway.requestAuthorization(req).failed) {
+      inside(gateway.requestAuthorization(req).failed.futureValue) {
         case ex: BusinessException =>
           expect(ex.message.messageId === "CODE-007")
           expect(ex.message.messageContent.contains("承認売上送信の際に、HTTPヘッダの内容が不正です。"))
@@ -104,7 +104,7 @@ class IssuingServiceGatewaySpec
         IssuingServiceMock.`IS:承認売上要求でその他のエラーレスポンス(451)`,
       )
 
-      whenReady(gateway.requestAuthorization(req).failed) {
+      inside(gateway.requestAuthorization(req).failed.futureValue) {
         case ex: BusinessException =>
           expect(ex.message.messageId === "CODE-009")
           expect(ex.message.messageContent.contains("承認売上送信の際に、Issuing Service でのエラーが検知されました。エラーコード：-"))
@@ -117,7 +117,7 @@ class IssuingServiceGatewaySpec
         IssuingServiceMock.`IS:承認売上に対する障害取消要求で成功を返す`,
       )
 
-      whenReady(gateway.requestAuthorization(req).failed) {
+      inside(gateway.requestAuthorization(req).failed.futureValue) {
         case ex: BusinessException =>
           expect(ex.message.messageId === "CODE-008")
           expect(ex.message.messageContent.contains("障害取消送信の際に、業務処理にて障害取消が必要なエラーが検知されました。"))
@@ -130,7 +130,7 @@ class IssuingServiceGatewaySpec
         IssuingServiceMock.`IS:承認売上に対する障害取消要求で成功を返す`,
       )
 
-      whenReady(gateway.requestAuthorization(req).failed) {
+      inside(gateway.requestAuthorization(req).failed.futureValue) {
         case ex: BusinessException =>
           expect(ex.message.messageId === "CODE-008")
           expect(ex.message.messageContent.contains("障害取消送信の際に、業務処理にて障害取消が必要なエラーが検知されました。"))
@@ -143,7 +143,7 @@ class IssuingServiceGatewaySpec
         IssuingServiceMock.`IS:承認売上に対する障害取消要求でBadRequestを返す(400)`,
       )
 
-      whenReady(gateway.requestAuthorization(req).failed) {
+      inside(gateway.requestAuthorization(req).failed.futureValue) {
         case ex: BusinessException =>
           expect(ex.message.messageId === "CODE-007")
           expect(ex.message.messageContent.contains("障害取消送信の際に、HTTPヘッダの内容が不正です。"))
@@ -156,7 +156,7 @@ class IssuingServiceGatewaySpec
         IssuingServiceMock.`IS:承認売上に対する障害取消要求でServiceUnavailableを返す(503)`,
       )
 
-      whenReady(gateway.requestAuthorization(req).failed) {
+      inside(gateway.requestAuthorization(req).failed.futureValue) {
         case ex: BusinessException =>
           expect(ex.message.messageId === "CODE-009")
           expect(ex.message.messageContent.contains("障害取消送信の際に、Issuing Service でのエラーが検知されました。"))
@@ -169,7 +169,7 @@ class IssuingServiceGatewaySpec
         IssuingServiceMock.`IS:承認売上に対する障害取消要求でServerErrorを返す(500)`,
       )
 
-      whenReady(gateway.requestAuthorization(req).failed) {
+      inside(gateway.requestAuthorization(req).failed.futureValue) {
         case ex: BusinessException =>
           expect(ex.message.messageId === "CODE-009")
           expect(ex.message.messageContent.contains("障害取消送信の際に、Issuing Service でのエラーが検知されました。"))
@@ -182,7 +182,7 @@ class IssuingServiceGatewaySpec
         IssuingServiceMock.`IS:承認売上に対する障害取消要求でその他のエラーを返す(451)`,
       )
 
-      whenReady(gateway.requestAuthorization(req).failed) {
+      inside(gateway.requestAuthorization(req).failed.futureValue) {
         case ex: BusinessException =>
           expect(ex.message.messageId === "CODE-009")
           expect(ex.message.messageContent.contains("障害取消送信の際に、Issuing Service でのエラーが検知されました。"))
@@ -210,7 +210,7 @@ class IssuingServiceGatewaySpec
         IssuingServiceMock.`IS:承認売上要求／承認取消要求でBadRequestを返す`,
       )
 
-      whenReady(gateway.requestAcquirerReversal(acquirerReversalRequestParameter, originalRequest).failed) {
+      inside(gateway.requestAcquirerReversal(acquirerReversalRequestParameter, originalRequest).failed.futureValue) {
         case ex: BusinessException =>
           expect(ex.message.messageId === "CODE-007")
           expect(ex.message.messageContent.contains("承認取消送信の際に、HTTPヘッダの内容が不正です。"))
@@ -254,12 +254,10 @@ class IssuingServiceGatewaySpec
         IssuingServiceMock.`IS:タイムアウトさせる`,
       )
 
-      whenReady(newGateway.requestAcquirerReversal(acquirerReversalRequestParameter, originalRequest).failed) {
+      inside(newGateway.requestAcquirerReversal(acquirerReversalRequestParameter, originalRequest).failed.futureValue) {
         case ex: BusinessException =>
           expect(ex.message.messageId === "CODE-005")
           expect(ex.message.messageContent.contains("障害取消送信でタイムアウトが発生しました。処理を中断します。"))
-        case _ =>
-          expect(false)
       }
     }
 

--- a/payment-app/presentation/src/main/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/body/IssuingServiceECPaymentRequest.scala
+++ b/payment-app/presentation/src/main/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/body/IssuingServiceECPaymentRequest.scala
@@ -34,7 +34,7 @@ object IssuingServiceECPaymentRequest {
           ),
         )
       else
-        Success,
+        Success
     }
 
   @SuppressWarnings(Array("org.wartremover.contrib.warts.MissingOverride"))

--- a/payment-app/presentation/src/main/scala/jp/co/tis/lerna/payment/presentation/management/MetricsRoute.scala
+++ b/payment-app/presentation/src/main/scala/jp/co/tis/lerna/payment/presentation/management/MetricsRoute.scala
@@ -29,7 +29,7 @@ class MetricsRoute(config: Config, metrics: Metrics) extends SprayJsonSupport {
   }
 
   private[this] def extractTenantParameter: Directive1[Option[AppTenant]] =
-    parameter('tenant.?).flatMap {
+    parameter("tenant".?).flatMap {
       case None => provide(None)
       case Some(tenantId) =>
         Try(AppTenant.withId(tenantId)) match {

--- a/payment-app/presentation/src/main/scala/jp/co/tis/lerna/payment/presentation/util/api/impl/ApiThrottlingImpl.scala
+++ b/payment-app/presentation/src/main/scala/jp/co/tis/lerna/payment/presentation/util/api/impl/ApiThrottlingImpl.scala
@@ -19,7 +19,7 @@ class ApiThrottlingImpl(rootConfig: Config) extends ApiThrottling with AppLoggin
       tenant <- AppTenant.values
       apiId  <- ApiId.values.toSeq
     } yield {
-      val apiConfig = config.getConfig(s"tenants.${tenant.id}.$apiId")
+      val apiConfig = config.getConfig(s"tenants.${tenant.id}.${apiId.toString}")
       val apiThrottlingState: ApiThrottlingState =
         if (!apiConfig.getBoolean("active")) Inactive
         else if (!apiConfig.getBoolean("rate-limit.active")) Nolimit
@@ -38,7 +38,8 @@ class ApiThrottlingImpl(rootConfig: Config) extends ApiThrottling with AppLoggin
   override def stateOf(apiId: ApiId)(implicit tenant: Tenant): ApiThrottlingState =
     apiThrottlingStateMap.get((apiId, tenant)) match {
       case Some(apiThrottlingState) => apiThrottlingState
-      case None                     => throw new IllegalStateException(s"流量制限設定不備のため処理できません。 apiId: $apiId, tenant: ${tenant.id}")
+      case None =>
+        throw new IllegalStateException(s"流量制限設定不備のため処理できません。 apiId: ${apiId.toString}, tenant: ${tenant.id}")
     }
 }
 

--- a/payment-app/presentation/src/main/scala/jp/co/tis/lerna/payment/presentation/util/directives/rejection/AppRejectionHandler.scala
+++ b/payment-app/presentation/src/main/scala/jp/co/tis/lerna/payment/presentation/util/directives/rejection/AppRejectionHandler.scala
@@ -43,10 +43,10 @@ trait AppRejectionHandler
               respondWithContentTypeApplicationJsonUTF8 {
                 rejection match {
                   case inactiveApiRejection: InactiveApiRejection =>
-                    logger.info(s"APIが閉局されていたため拒否しました。 $inactiveApiRejection")
+                    logger.info(s"APIが閉局されていたため拒否しました。 ${inactiveApiRejection.toString}")
                     complete(StatusCodes.ServiceUnavailable -> maintenance)
                   case tooManyRequestsRejection: TooManyRequestsRejection =>
-                    logger.info(s"APIごとのレート制限を超えるリクエストを拒否しました。 $tooManyRequestsRejection")
+                    logger.info(s"APIごとのレート制限を超えるリクエストを拒否しました。 ${tooManyRequestsRejection.toString}")
                     complete(StatusCodes.ServiceUnavailable -> tooManyRequests)
                   case _: AuthenticationFailedRejection =>
                     complete(StatusCodes.Unauthorized -> unauthorized)
@@ -57,7 +57,7 @@ trait AppRejectionHandler
                       StatusCodes.MethodNotAllowed -> s"HTTP method not allowed, supported methods: ${rejection.supported.name}",
                     )
                   case other =>
-                    logger.warn(s"rejection: $other")
+                    logger.warn(s"rejection: ${other.toString}")
                     complete(StatusCodes.InternalServerError -> HttpEntity.Empty)
                 }
               }

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/IssuingServiceGatewayPaymentCancelSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/IssuingServiceGatewayPaymentCancelSpec.scala
@@ -54,7 +54,7 @@ object IssuingServiceGatewayPaymentCancelSpec {
         scopes: Seq[AuthorizationScope],
     )(implicit appRequestContext: AppRequestContext): Directive1[(CustomerId, ClientId)] = {
       import AuthorizationScope.OSettlementWrite
-      require(scopes.contains(OSettlementWrite), s"scopes($scopes) に ${OSettlementWrite.value} が入っていません")
+      require(scopes.contains(OSettlementWrite), s"scopes(${scopes.toString}) に ${OSettlementWrite.value} が入っていません")
       provide(
         (
           CustomerId("1"),

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/IssuingServiceGatewayPaymentSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/IssuingServiceGatewayPaymentSpec.scala
@@ -54,7 +54,7 @@ object IssuingServiceGatewayPaymentSpec {
         scopes: Seq[AuthorizationScope],
     )(implicit appRequestContext: AppRequestContext): Directive1[(CustomerId, ClientId)] = {
       import AuthorizationScope.OSettlementWrite
-      require(scopes.contains(OSettlementWrite), s"scopes($scopes) に ${OSettlementWrite.value} が入っていません")
+      require(scopes.contains(OSettlementWrite), s"scopes(${scopes.toString}) に ${OSettlementWrite.value} が入っていません")
       provide(
         (
           CustomerId("1"),

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/IssuingServiceGatewayPaymentSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/ecpayment/issuing/payment/IssuingServiceGatewayPaymentSpec.scala
@@ -209,7 +209,7 @@ class IssuingServiceGatewayPaymentSpec
         request ~> settlement.route() ~> check {
           rejections.map { rejection =>
             rejection shouldBe a[MalformedRequestContentRejection]
-            rejection match {
+            inside(rejection) {
               case m: MalformedRequestContentRejection =>
                 m.message should ===("Object is missing required member 'orderId'")
             }
@@ -308,7 +308,7 @@ class IssuingServiceGatewayPaymentSpec
         request ~> settlement.route() ~> check {
           rejections.map { rejection =>
             rejection shouldBe a[MalformedRequestContentRejection]
-            rejection match {
+            inside(rejection) {
               case m: MalformedRequestContentRejection =>
                 m.message should ===("Object is missing required member 'amount'")
             }

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/util/api/ApiThrottlingSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/util/api/ApiThrottlingSpec.scala
@@ -17,7 +17,7 @@ import wvlet.airframe.{ newDesign, Design, Session }
 )
 class ApiThrottlingSpec extends StandardSpec with Inside with DISessionSupport {
 
-  private def withDiChildSession(childDesign: Design)(testCode: Session => Any) {
+  private def withDiChildSession(childDesign: Design)(testCode: Session => Any): Unit = {
     diSession.withChildSession(childDesign) { childSession =>
       testCode(childSession)
     }

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/util/api/ApiThrottlingSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/util/api/ApiThrottlingSpec.scala
@@ -42,7 +42,7 @@ class ApiThrottlingSpec extends StandardSpec with Inside with DISessionSupport {
       val rootConfig = ConfigFactory
         .parseString(s"""
            |jp.co.tis.lerna.payment.presentation.util.api.tenants.${tenant.id} {
-           |  ${apiId} {
+           |  ${apiId.toString} {
            |    // on: 開局, off: 閉局
            |    active = off
            |  }
@@ -62,7 +62,7 @@ class ApiThrottlingSpec extends StandardSpec with Inside with DISessionSupport {
         val rootConfig = ConfigFactory
           .parseString(s"""
                                                       |jp.co.tis.lerna.payment.presentation.util.api.tenants.${tenant.id} {
-                                                      |  ${apiId} {
+                                                      |  ${apiId.toString} {
                                                       |    // on: 開局, off: 閉局
                                                       |    active = on
                                                       |    rate-limit {
@@ -89,14 +89,14 @@ class ApiThrottlingSpec extends StandardSpec with Inside with DISessionSupport {
         val rootConfig = ConfigFactory
           .parseString(s"""
                                                       |jp.co.tis.lerna.payment.presentation.util.api.tenants.${tenant.id} {
-                                                      |  ${apiId} {
+                                                      |  ${apiId.toString} {
                                                       |    // on: 開局, off: 閉局
                                                       |    active = on
                                                       |    rate-limit {
                                                       |      // 流量制限 (TPS)
                                                       |      active = on
-                                                      |      transactions = ${transactions}
-                                                      |      duration     = ${duration.toSeconds} s // 秒以上単位
+                                                      |      transactions = ${transactions.toString}
+                                                      |      duration     = ${duration.toSeconds.toString} s // 秒以上単位
                                                       |    }
                                                       |  }
                                                       |}

--- a/payment-app/read-model-testkit/src/main/scala/jp/co/tis/lerna/payment/readmodel/TableSeeds.scala
+++ b/payment-app/read-model-testkit/src/main/scala/jp/co/tis/lerna/payment/readmodel/TableSeeds.scala
@@ -1,6 +1,5 @@
 package jp.co.tis.lerna.payment.readmodel
 
-import jp.co.tis.lerna.payment.readmodel.schema.Tables
 import jp.co.tis.lerna.payment.readmodel.constant.LogicalDeleteFlag
 import jp.co.tis.lerna.payment.readmodel.schema.Tables
 

--- a/payment-app/read-model/src/main/scala/jp/co/tis/lerna/payment/readmodel/JDBCService.scala
+++ b/payment-app/read-model/src/main/scala/jp/co/tis/lerna/payment/readmodel/JDBCService.scala
@@ -13,11 +13,11 @@ trait JDBCService {
 
   private[this] val config = bind[Config]
 
-  def db()(implicit tenant: AppTenant): JdbcBackend#Database = {
+  def db(implicit tenant: AppTenant): JdbcBackend#Database = {
     dbConfigMap(tenant).db
   }
 
-  def dbConfig()(implicit tenant: AppTenant): DatabaseConfig[JdbcProfile] = {
+  def dbConfig(implicit tenant: AppTenant): DatabaseConfig[JdbcProfile] = {
     dbConfigMap(tenant)
   }
 

--- a/payment-app/read-model/src/main/scala/jp/co/tis/lerna/payment/readmodel/schema/Tables.scala
+++ b/payment-app/read-model/src/main/scala/jp/co/tis/lerna/payment/readmodel/schema/Tables.scala
@@ -6,6 +6,7 @@ package jp.co.tis.lerna.payment.readmodel.schema
     "org.wartremover.warts.AsInstanceOf",
     "org.wartremover.warts.OptionPartial",
     "org.wartremover.warts.Throw",
+    "org.wartremover.warts.TraversableOps",
     "org.wartremover.contrib.warts.MissingOverride",
     "org.wartremover.contrib.warts.SomeApply",
     "lerna.warts.NamingDef",

--- a/payment-app/read-model/src/main/scala/jp/co/tis/lerna/payment/readmodel/schema/Tables.scala
+++ b/payment-app/read-model/src/main/scala/jp/co/tis/lerna/payment/readmodel/schema/Tables.scala
@@ -78,40 +78,37 @@ trait Tables {
   }
 
   /** Table description of table CUSTOMER. Objects of this class serve as prototypes for rows in queries. */
+
   class Customer(_tableTag: Tag) extends profile.api.Table[CustomerRow](_tableTag, None, "CUSTOMER") {
-    def * =
-      (
-        customerId,
-        customerNumber,
-        walletId,
-        insertDate,
-        insertUserId,
-        updateDate,
-        updateUserId,
-        versionNo,
-        logicalDeleteFlag,
-      ) <> (CustomerRow.tupled, CustomerRow.unapply)
+    def * = (
+      customerId,
+      customerNumber,
+      walletId,
+      insertDate,
+      insertUserId,
+      updateDate,
+      updateUserId,
+      versionNo,
+      logicalDeleteFlag,
+    ) <> (CustomerRow.tupled, CustomerRow.unapply)
 
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
+    def ? = (
       (
-        (
-          Rep.Some(customerId),
-          customerNumber,
-          walletId,
-          Rep.Some(insertDate),
-          Rep.Some(insertUserId),
-          updateDate,
-          updateUserId,
-          Rep.Some(versionNo),
-          Rep.Some(logicalDeleteFlag),
-        ),
-      ).shaped.<>(
-        { r =>
-          import r._; _1.map(_ => CustomerRow.tupled((_1.get, _2, _3, _4.get, _5.get, _6, _7, _8.get, _9.get)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported."),
-      )
+        Rep.Some(customerId),
+        customerNumber,
+        walletId,
+        Rep.Some(insertDate),
+        Rep.Some(insertUserId),
+        updateDate,
+        updateUserId,
+        Rep.Some(versionNo),
+        Rep.Some(logicalDeleteFlag),
+      ),
+    ).shaped.<>(
+      { r => import r._; _1.map(_ => CustomerRow.tupled((_1.get, _2, _3, _4.get, _5.get, _6, _7, _8.get, _9.get))) },
+      (_: Any) => throw new Exception("Inserting into ? projection not supported."),
+    )
 
     /** Database column CUSTOMER_ID SqlType(CHAR), PrimaryKey, Length(32,false) */
     val customerId: Rep[String] = column[String]("CUSTOMER_ID", O.PrimaryKey, O.Length(32, varying = false))
@@ -204,51 +201,51 @@ trait Tables {
   }
 
   /** Table description of table HOUSE_MEMBER_STORE. Objects of this class serve as prototypes for rows in queries. */
+
   class HouseMemberStore(_tableTag: Tag)
       extends profile.api.Table[HouseMemberStoreRow](_tableTag, None, "HOUSE_MEMBER_STORE") {
-    def * =
-      (
-        memberStoreId,
-        memberStoreNameJp,
-        memberStoreNameEn,
-        terminalId,
-        clientId,
-        walletShopId,
-        insertDate,
-        insertUserId,
-        updateDate,
-        updateUserId,
-        versionNo,
-        logicalDeleteFlag,
-      ) <> (HouseMemberStoreRow.tupled, HouseMemberStoreRow.unapply)
+    def * = (
+      memberStoreId,
+      memberStoreNameJp,
+      memberStoreNameEn,
+      terminalId,
+      clientId,
+      walletShopId,
+      insertDate,
+      insertUserId,
+      updateDate,
+      updateUserId,
+      versionNo,
+      logicalDeleteFlag,
+    ) <> (HouseMemberStoreRow.tupled, HouseMemberStoreRow.unapply)
 
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
+    def ? = (
       (
-        (
-          Rep.Some(memberStoreId),
-          memberStoreNameJp,
-          memberStoreNameEn,
-          Rep.Some(terminalId),
-          Rep.Some(clientId),
-          Rep.Some(walletShopId),
-          Rep.Some(insertDate),
-          Rep.Some(insertUserId),
-          updateDate,
-          updateUserId,
-          Rep.Some(versionNo),
-          Rep.Some(logicalDeleteFlag),
-        ),
-      ).shaped.<>(
-        { r =>
-          import r._;
-          _1.map(_ =>
-            HouseMemberStoreRow
-              .tupled((_1.get, _2, _3, _4.get, _5.get, _6.get, _7.get, _8.get, _9, _10, _11.get, _12.get)),
-          )
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported."),
-      )
+        Rep.Some(memberStoreId),
+        memberStoreNameJp,
+        memberStoreNameEn,
+        Rep.Some(terminalId),
+        Rep.Some(clientId),
+        Rep.Some(walletShopId),
+        Rep.Some(insertDate),
+        Rep.Some(insertUserId),
+        updateDate,
+        updateUserId,
+        Rep.Some(versionNo),
+        Rep.Some(logicalDeleteFlag),
+      ),
+    ).shaped.<>(
+      { r =>
+        import r._;
+        _1.map(_ =>
+          HouseMemberStoreRow.tupled(
+            (_1.get, _2, _3, _4.get, _5.get, _6.get, _7.get, _8.get, _9, _10, _11.get, _12.get),
+          ),
+        )
+      },
+      (_: Any) => throw new Exception("Inserting into ? projection not supported."),
+    )
 
     /** Database column MEMBER_STORE_ID SqlType(VARCHAR), Length(15,true) */
     val memberStoreId: Rep[String] = column[String]("MEMBER_STORE_ID", O.Length(15, varying = true))
@@ -356,53 +353,53 @@ trait Tables {
   }
 
   /** Table description of table INCENTIVE_MASTER. Objects of this class serve as prototypes for rows in queries. */
+
   class IncentiveMaster(_tableTag: Tag)
       extends profile.api.Table[IncentiveMasterRow](_tableTag, None, "INCENTIVE_MASTER") {
-    def * =
-      (
-        incentiveMasterId,
-        settlementType,
-        incentiveType,
-        incentiveRate,
-        incentiveAmount,
-        incentiveDateFrom,
-        incentiveDateTo,
-        insertDate,
-        insertUserId,
-        updateDate,
-        updateUserId,
-        versionNo,
-        logicalDeleteFlag,
-      ) <> (IncentiveMasterRow.tupled, IncentiveMasterRow.unapply)
+    def * = (
+      incentiveMasterId,
+      settlementType,
+      incentiveType,
+      incentiveRate,
+      incentiveAmount,
+      incentiveDateFrom,
+      incentiveDateTo,
+      insertDate,
+      insertUserId,
+      updateDate,
+      updateUserId,
+      versionNo,
+      logicalDeleteFlag,
+    ) <> (IncentiveMasterRow.tupled, IncentiveMasterRow.unapply)
 
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
+    def ? = (
       (
-        (
-          Rep.Some(incentiveMasterId),
-          Rep.Some(settlementType),
-          Rep.Some(incentiveType),
-          incentiveRate,
-          incentiveAmount,
-          Rep.Some(incentiveDateFrom),
-          Rep.Some(incentiveDateTo),
-          Rep.Some(insertDate),
-          Rep.Some(insertUserId),
-          updateDate,
-          updateUserId,
-          Rep.Some(versionNo),
-          Rep.Some(logicalDeleteFlag),
-        ),
-      ).shaped.<>(
-        { r =>
-          import r._;
-          _1.map(_ =>
-            IncentiveMasterRow
-              .tupled((_1.get, _2.get, _3.get, _4, _5, _6.get, _7.get, _8.get, _9.get, _10, _11, _12.get, _13.get)),
-          )
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported."),
-      )
+        Rep.Some(incentiveMasterId),
+        Rep.Some(settlementType),
+        Rep.Some(incentiveType),
+        incentiveRate,
+        incentiveAmount,
+        Rep.Some(incentiveDateFrom),
+        Rep.Some(incentiveDateTo),
+        Rep.Some(insertDate),
+        Rep.Some(insertUserId),
+        updateDate,
+        updateUserId,
+        Rep.Some(versionNo),
+        Rep.Some(logicalDeleteFlag),
+      ),
+    ).shaped.<>(
+      { r =>
+        import r._;
+        _1.map(_ =>
+          IncentiveMasterRow.tupled(
+            (_1.get, _2.get, _3.get, _4, _5, _6.get, _7.get, _8.get, _9.get, _10, _11, _12.get, _13.get),
+          ),
+        )
+      },
+      (_: Any) => throw new Exception("Inserting into ? projection not supported."),
+    )
 
     /** Database column INCENTIVE_MASTER_ID SqlType(DECIMAL), PrimaryKey */
     val incentiveMasterId: Rep[scala.math.BigDecimal] =
@@ -500,44 +497,42 @@ trait Tables {
   }
 
   /** Table description of table ISSUING_SERVICE. Objects of this class serve as prototypes for rows in queries. */
+
   class IssuingService(_tableTag: Tag)
       extends profile.api.Table[IssuingServiceRow](_tableTag, None, "ISSUING_SERVICE") {
-    def * =
+    def * = (
+      contractNumber,
+      housePan,
+      serviceRelationId,
+      digit4byte,
+      insertDate,
+      insertUserId,
+      updateDate,
+      updateUserId,
+      versionNo,
+      logicalDeleteFlag,
+    ) <> (IssuingServiceRow.tupled, IssuingServiceRow.unapply)
+
+    /** Maps whole row to an option. Useful for outer joins. */
+    def ? = (
       (
-        contractNumber,
+        Rep.Some(contractNumber),
         housePan,
         serviceRelationId,
         digit4byte,
-        insertDate,
-        insertUserId,
+        Rep.Some(insertDate),
+        Rep.Some(insertUserId),
         updateDate,
         updateUserId,
-        versionNo,
-        logicalDeleteFlag,
-      ) <> (IssuingServiceRow.tupled, IssuingServiceRow.unapply)
-
-    /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      (
-        (
-          Rep.Some(contractNumber),
-          housePan,
-          serviceRelationId,
-          digit4byte,
-          Rep.Some(insertDate),
-          Rep.Some(insertUserId),
-          updateDate,
-          updateUserId,
-          Rep.Some(versionNo),
-          Rep.Some(logicalDeleteFlag),
-        ),
-      ).shaped.<>(
-        { r =>
-          import r._;
-          _1.map(_ => IssuingServiceRow.tupled((_1.get, _2, _3, _4, _5.get, _6.get, _7, _8, _9.get, _10.get)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported."),
-      )
+        Rep.Some(versionNo),
+        Rep.Some(logicalDeleteFlag),
+      ),
+    ).shaped.<>(
+      { r =>
+        import r._; _1.map(_ => IssuingServiceRow.tupled((_1.get, _2, _3, _4, _5.get, _6.get, _7, _8, _9.get, _10.get)))
+      },
+      (_: Any) => throw new Exception("Inserting into ? projection not supported."),
+    )
 
     /** Database column CONTRACT_NUMBER SqlType(CHAR), PrimaryKey, Length(10,false) */
     val contractNumber: Rep[String] = column[String]("CONTRACT_NUMBER", O.PrimaryKey, O.Length(10, varying = false))
@@ -709,60 +704,60 @@ trait Tables {
   }
 
   /** Table description of table SALES_DETAIL. Objects of this class serve as prototypes for rows in queries. */
+
   class SalesDetail(_tableTag: Tag) extends profile.api.Table[SalesDetailRow](_tableTag, None, "SALES_DETAIL") {
     def * =
       (walletSettlementId :: settlementType :: walletId :: customerNumber :: dealStatus :: specificDealInfo :: originDealId :: contractNumber :: maskingInfo :: saleDatetime :: dealDate :: saleCancelType :: sendDatetime :: authoriNumber :: amount :: memberStoreId :: memberStorePosId :: memberStoreName :: failureCancelFlag :: errorCode :: dealSerialNumber :: paymentId :: originalPaymentId :: cashBackTempAmount :: cashBackFixedAmount :: applicationExtractFlag :: customerId :: saleExtractedFlag :: eventPersistenceId :: eventSequenceNumber :: insertDate :: insertUserId :: updateDate :: updateUserId :: versionNo :: logicalDeleteFlag :: HNil)
         .mapTo[SalesDetailRow]
 
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
-      (Rep.Some(
-        walletSettlementId,
-      ) :: settlementType :: walletId :: customerNumber :: dealStatus :: specificDealInfo :: originDealId :: contractNumber :: maskingInfo :: saleDatetime :: dealDate :: saleCancelType :: sendDatetime :: authoriNumber :: amount :: memberStoreId :: memberStorePosId :: memberStoreName :: failureCancelFlag :: errorCode :: dealSerialNumber :: paymentId :: originalPaymentId :: cashBackTempAmount :: cashBackFixedAmount :: applicationExtractFlag :: customerId :: saleExtractedFlag :: eventPersistenceId :: eventSequenceNumber :: Rep
-        .Some(insertDate) :: Rep.Some(insertUserId) :: updateDate :: updateUserId :: Rep.Some(versionNo) :: Rep.Some(
-        logicalDeleteFlag,
-      ) :: HNil).shaped.<>(
-        r =>
-          SalesDetailRow(
-            r(0).asInstanceOf[Option[scala.math.BigDecimal]].get,
-            r(1).asInstanceOf[Option[String]],
-            r(2).asInstanceOf[Option[String]],
-            r(3).asInstanceOf[Option[String]],
-            r(4).asInstanceOf[Option[String]],
-            r(5).asInstanceOf[Option[String]],
-            r(6).asInstanceOf[Option[String]],
-            r(7).asInstanceOf[Option[String]],
-            r(8).asInstanceOf[Option[String]],
-            r(9).asInstanceOf[Option[java.sql.Timestamp]],
-            r(10).asInstanceOf[Option[java.sql.Timestamp]],
-            r(11).asInstanceOf[Option[String]],
-            r(12).asInstanceOf[Option[java.sql.Timestamp]],
-            r(13).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(14).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(15).asInstanceOf[Option[String]],
-            r(16).asInstanceOf[Option[String]],
-            r(17).asInstanceOf[Option[String]],
-            r(18).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(19).asInstanceOf[Option[String]],
-            r(20).asInstanceOf[Option[String]],
-            r(21).asInstanceOf[Option[String]],
-            r(22).asInstanceOf[Option[String]],
-            r(23).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(24).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(25).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(26).asInstanceOf[Option[String]],
-            r(27).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(28).asInstanceOf[Option[String]],
-            r(29).asInstanceOf[Option[scala.math.BigDecimal]],
-            r(30).asInstanceOf[Option[java.sql.Timestamp]].get,
-            r(31).asInstanceOf[Option[String]].get,
-            r(32).asInstanceOf[Option[java.sql.Timestamp]],
-            r(33).asInstanceOf[Option[String]],
-            r(34).asInstanceOf[Option[scala.math.BigDecimal]].get,
-            r(35).asInstanceOf[Option[scala.math.BigDecimal]].get,
-          ),
-        (_: Any) => throw new Exception("Inserting into ? projection not supported."),
-      )
+    def ? = (Rep.Some(
+      walletSettlementId,
+    ) :: settlementType :: walletId :: customerNumber :: dealStatus :: specificDealInfo :: originDealId :: contractNumber :: maskingInfo :: saleDatetime :: dealDate :: saleCancelType :: sendDatetime :: authoriNumber :: amount :: memberStoreId :: memberStorePosId :: memberStoreName :: failureCancelFlag :: errorCode :: dealSerialNumber :: paymentId :: originalPaymentId :: cashBackTempAmount :: cashBackFixedAmount :: applicationExtractFlag :: customerId :: saleExtractedFlag :: eventPersistenceId :: eventSequenceNumber :: Rep
+      .Some(insertDate) :: Rep.Some(insertUserId) :: updateDate :: updateUserId :: Rep.Some(versionNo) :: Rep.Some(
+      logicalDeleteFlag,
+    ) :: HNil).shaped.<>(
+      r =>
+        SalesDetailRow(
+          r(0).asInstanceOf[Option[scala.math.BigDecimal]].get,
+          r(1).asInstanceOf[Option[String]],
+          r(2).asInstanceOf[Option[String]],
+          r(3).asInstanceOf[Option[String]],
+          r(4).asInstanceOf[Option[String]],
+          r(5).asInstanceOf[Option[String]],
+          r(6).asInstanceOf[Option[String]],
+          r(7).asInstanceOf[Option[String]],
+          r(8).asInstanceOf[Option[String]],
+          r(9).asInstanceOf[Option[java.sql.Timestamp]],
+          r(10).asInstanceOf[Option[java.sql.Timestamp]],
+          r(11).asInstanceOf[Option[String]],
+          r(12).asInstanceOf[Option[java.sql.Timestamp]],
+          r(13).asInstanceOf[Option[scala.math.BigDecimal]],
+          r(14).asInstanceOf[Option[scala.math.BigDecimal]],
+          r(15).asInstanceOf[Option[String]],
+          r(16).asInstanceOf[Option[String]],
+          r(17).asInstanceOf[Option[String]],
+          r(18).asInstanceOf[Option[scala.math.BigDecimal]],
+          r(19).asInstanceOf[Option[String]],
+          r(20).asInstanceOf[Option[String]],
+          r(21).asInstanceOf[Option[String]],
+          r(22).asInstanceOf[Option[String]],
+          r(23).asInstanceOf[Option[scala.math.BigDecimal]],
+          r(24).asInstanceOf[Option[scala.math.BigDecimal]],
+          r(25).asInstanceOf[Option[scala.math.BigDecimal]],
+          r(26).asInstanceOf[Option[String]],
+          r(27).asInstanceOf[Option[scala.math.BigDecimal]],
+          r(28).asInstanceOf[Option[String]],
+          r(29).asInstanceOf[Option[scala.math.BigDecimal]],
+          r(30).asInstanceOf[Option[java.sql.Timestamp]].get,
+          r(31).asInstanceOf[Option[String]].get,
+          r(32).asInstanceOf[Option[java.sql.Timestamp]],
+          r(33).asInstanceOf[Option[String]],
+          r(34).asInstanceOf[Option[scala.math.BigDecimal]].get,
+          r(35).asInstanceOf[Option[scala.math.BigDecimal]].get,
+        ),
+      (_: Any) => throw new Exception("Inserting into ? projection not supported."),
+    )
 
     /** Database column WALLET_SETTLEMENT_ID SqlType(DECIMAL), PrimaryKey */
     val walletSettlementId: Rep[scala.math.BigDecimal] =
@@ -947,42 +942,41 @@ trait Tables {
   }
 
   /** Table description of table SERVICE_RELATION. Objects of this class serve as prototypes for rows in queries. */
+
   class ServiceRelation(_tableTag: Tag)
       extends profile.api.Table[ServiceRelationRow](_tableTag, None, "SERVICE_RELATION") {
-    def * =
-      (
-        serviceRelationId,
-        foreignKeyType,
-        customerId,
-        insertDate,
-        insertUserId,
-        updateDate,
-        updateUserId,
-        versionNo,
-        logicalDeleteFlag,
-      ) <> (ServiceRelationRow.tupled, ServiceRelationRow.unapply)
+    def * = (
+      serviceRelationId,
+      foreignKeyType,
+      customerId,
+      insertDate,
+      insertUserId,
+      updateDate,
+      updateUserId,
+      versionNo,
+      logicalDeleteFlag,
+    ) <> (ServiceRelationRow.tupled, ServiceRelationRow.unapply)
 
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? =
+    def ? = (
       (
-        (
-          Rep.Some(serviceRelationId),
-          Rep.Some(foreignKeyType),
-          Rep.Some(customerId),
-          Rep.Some(insertDate),
-          Rep.Some(insertUserId),
-          updateDate,
-          updateUserId,
-          Rep.Some(versionNo),
-          Rep.Some(logicalDeleteFlag),
-        ),
-      ).shaped.<>(
-        { r =>
-          import r._;
-          _1.map(_ => ServiceRelationRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7, _8.get, _9.get)))
-        },
-        (_: Any) => throw new Exception("Inserting into ? projection not supported."),
-      )
+        Rep.Some(serviceRelationId),
+        Rep.Some(foreignKeyType),
+        Rep.Some(customerId),
+        Rep.Some(insertDate),
+        Rep.Some(insertUserId),
+        updateDate,
+        updateUserId,
+        Rep.Some(versionNo),
+        Rep.Some(logicalDeleteFlag),
+      ),
+    ).shaped.<>(
+      { r =>
+        import r._;
+        _1.map(_ => ServiceRelationRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7, _8.get, _9.get)))
+      },
+      (_: Any) => throw new Exception("Inserting into ? projection not supported."),
+    )
 
     /** Database column SERVICE_RELATION_ID SqlType(DECIMAL), PrimaryKey */
     val serviceRelationId: Rep[scala.math.BigDecimal] =

--- a/slick-codegen/src/main/scala/Codegen.scala
+++ b/slick-codegen/src/main/scala/Codegen.scala
@@ -23,7 +23,7 @@ object Codegen extends App {
 
   val config                         = ConfigFactory.load().getConfig("slick.codegen")
   val dbConfig                       = DatabaseConfig.forConfig[JdbcProfile]("", config)
-  val excludeTableNames: Seq[String] = config.getStringList("excludeTableNames").asScala
+  val excludeTableNames: Seq[String] = config.getStringList("excludeTableNames").asScala.toSeq
   import dbConfig._
 
   val tables = profile.defaultTables.map(_.filterNot { table =>

--- a/slick-codegen/src/main/scala/Codegen.scala
+++ b/slick-codegen/src/main/scala/Codegen.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.{ Failure, Success }
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 @SuppressWarnings(
   Array(

--- a/slick-codegen/src/main/scala/Codegen.scala
+++ b/slick-codegen/src/main/scala/Codegen.scala
@@ -33,10 +33,10 @@ object Codegen extends App {
   // fetch data model
   val model = for {
     modelAction <-
-    // HACK カスタマイズした CustomJdbcModelBuilder を使います。詳しい経緯は README を参照してください。
-    // profile.createModel(Option(tables), ignoreInvalidDefaults = false) // you can filter specific tables here
-    new CustomJdbcModelComponentExt(profile.asInstanceOf[MySQLProfile])
-      .createModel(Option(tables), ignoreInvalidDefaults = false)
+      // HACK カスタマイズした CustomJdbcModelBuilder を使います。詳しい経緯は README を参照してください。
+      // profile.createModel(Option(tables), ignoreInvalidDefaults = false) // you can filter specific tables here
+      new CustomJdbcModelComponentExt(profile.asInstanceOf[MySQLProfile])
+        .createModel(Option(tables), ignoreInvalidDefaults = false)
   } yield modelAction
 
   val modelFuture = db.run(model)
@@ -46,13 +46,13 @@ object Codegen extends App {
     .map { model =>
       new SourceCodeGenerator(model) {
 
-        /**
-          * デフォルトからの変更点
+        /** デフォルトからの変更点
           * - slick.collection.heterogeneous.syntax のインポートを除去
           * - slick.model.ForeignKeyAction のインポートを除去
           */
         /** Generates code for the complete model (not wrapped in a package yet)
-      @group Basic customization overrides */
+          *      @group Basic customization overrides
+          */
         override def code = {
           // "import slick.model.ForeignKeyAction\n" +
           (if (tables.exists(table => table.hlistEnabled || table.isMappedToHugeClass)) {
@@ -67,8 +67,7 @@ object Codegen extends App {
           tables.map(_.code.mkString("\n")).mkString("\n\n")
         }
 
-        /**
-          * デフォルトからの変更点
+        /** デフォルトからの変更点
           * - Tables object を生成しない
           * - Schema を未指定（None）に変更
           */
@@ -102,7 +101,7 @@ object Codegen extends App {
               val args = model.name.schema.map(_ => s"""None""") ++ Seq("\"" + model.name.table + "\"")
               s"""
               |class $name(_tableTag: Tag) extends profile.api.Table[$elementType](_tableTag, ${args
-                   .mkString(", ")})$prns {
+                .mkString(", ")})$prns {
               |  ${indent(body.map(_.mkString("\n")).mkString("\n\n"))}
               |}
               """.stripMargin

--- a/slick-codegen/src/main/scala/Codegen.scala
+++ b/slick-codegen/src/main/scala/Codegen.scala
@@ -80,6 +80,7 @@ object Codegen extends App {
            |    "org.wartremover.warts.AsInstanceOf",
            |    "org.wartremover.warts.OptionPartial",
            |    "org.wartremover.warts.Throw",
+           |    "org.wartremover.warts.TraversableOps",
            |    "org.wartremover.contrib.warts.MissingOverride",
            |    "org.wartremover.contrib.warts.SomeApply",
            |    "lerna.warts.NamingDef",

--- a/slick-codegen/src/main/scala/CustomJdbcModelComponentExt.scala
+++ b/slick-codegen/src/main/scala/CustomJdbcModelComponentExt.scala
@@ -1,5 +1,4 @@
-/**
-  * Slick からコピーして一部を書き換えたコードです。
+/** Slick からコピーして一部を書き換えたコードです。
   * 詳しい経緯は README を参照してください。
   */
 import slick.dbio.DBIO
@@ -11,15 +10,15 @@ import scala.concurrent.ExecutionContext
 
 class CustomJdbcModelComponentExt(component: MySQLProfile) {
 
-  def createModel(tables: Option[DBIO[Seq[MTable]]] = None, ignoreInvalidDefaults: Boolean = true)(
-      implicit ec: ExecutionContext,
+  def createModel(tables: Option[DBIO[Seq[MTable]]] = None, ignoreInvalidDefaults: Boolean = true)(implicit
+      ec: ExecutionContext,
   ): DBIO[Model] = {
     val tablesA = tables.getOrElse(component.defaultTables)
     tablesA.flatMap(t => createModelBuilder(t, ignoreInvalidDefaults).buildModel)
   }
 
-  def createModelBuilder(tables: Seq[MTable], ignoreInvalidDefaults: Boolean)(
-      implicit ec: ExecutionContext,
+  def createModelBuilder(tables: Seq[MTable], ignoreInvalidDefaults: Boolean)(implicit
+      ec: ExecutionContext,
   ): JdbcModelBuilder = {
     new CustomMySQLModelBuilder(tables, ignoreInvalidDefaults)
   }

--- a/slick-codegen/src/main/scala/CustomMySQLModelBuilder.scala
+++ b/slick-codegen/src/main/scala/CustomMySQLModelBuilder.scala
@@ -1,5 +1,4 @@
-/**
-  * Slick からコピーして一部を書き換えたコードです。
+/** Slick からコピーして一部を書き換えたコードです。
   * 詳しい経緯は README を参照してください。
   */
 import slick.jdbc.MySQLProfile


### PR DESCRIPTION
2021/06/27 時点での最新 Scala 

[Release Scala 2.13.6 · scala/scala](https://github.com/scala/scala/releases/tag/v2.13.6)

## 動作確認
run して curl が成功

```
$ curl --include   --silent --show-error --noproxy '*'   -H 'Authorization:Bearer dummy' -H 'Content-Type:application/json' -H 'X-Tenant-Id:example'   -X PUT   -d '{ "amount":600 }'   "http://127.0.0.1:9001/00/ec/settlements/000000000000000000000000000000000000002/$(date +%s%3N)/payment"
HTTP/1.1 200 OK
Server: akka-http/10.2.4
Date: Mon, 28 Jun 2021 10:16:31 GMT
Content-Type: application/json; charset=UTF-8
Content-Length: 84

{"orderId":"1624875391047","walletShopId":"000000000000000000000000000000000000002"}
```