### PR TITLE
Update akka http 10.2

### DIFF
--- a/payment-app/entrypoint/src/main/scala/jp/co/tis/lerna/payment/entrypoint/PaymentApp.scala
+++ b/payment-app/entrypoint/src/main/scala/jp/co/tis/lerna/payment/entrypoint/PaymentApp.scala
@@ -5,7 +5,6 @@ import akka.actor.{ ActorSystem, CoordinatedShutdown, Scheduler }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.Http.ServerBinding
 import akka.http.scaladsl.server.Route
-import akka.stream.Materializer
 import com.typesafe.config.Config
 import jp.co.tis.lerna.payment.adapter.util.health.HealthCheckApplication
 import jp.co.tis.lerna.payment.application.readmodelupdater.ReadModelUpdaterManager
@@ -49,11 +48,10 @@ class PaymentApp(implicit
     }
   }
 
-  private[this] def startServer(typeName: String, route: Route, interface: String, port: Int)(implicit
-      fm: Materializer,
-  ): Unit = {
+  private[this] def startServer(typeName: String, route: Route, interface: String, port: Int): Unit = {
     Http()
-      .bindAndHandle(route, interface, port)
+      .newServerAt(interface, port)
+      .bind(route)
       .foreach { serverBinding =>
         addToShutdownHook(typeName, serverBinding)
       }

--- a/payment-app/entrypoint/src/main/scala/jp/co/tis/lerna/payment/entrypoint/PaymentApp.scala
+++ b/payment-app/entrypoint/src/main/scala/jp/co/tis/lerna/payment/entrypoint/PaymentApp.scala
@@ -51,7 +51,7 @@ class PaymentApp(implicit
   private[this] def startServer(typeName: String, route: Route, interface: String, port: Int): Unit = {
     Http()
       .newServerAt(interface, port)
-      .bind(route)
+      .bind(Route.seal(route))
       .foreach { serverBinding =>
         addToShutdownHook(typeName, serverBinding)
       }

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/util/directives/AuthorizationHeaderDirectiveSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/util/directives/AuthorizationHeaderDirectiveSpec.scala
@@ -72,7 +72,7 @@ class AuthorizationHeaderDirectiveSpec
     "異常系: tokenが適切なものではなかった Forbidden" in {
       val request =
         Post("/").addHeader(Authorization(OAuth2BearerToken("Forbidden")))
-      request ~> route ~> check {
+      request ~> Route.seal(route) ~> check {
         expect {
           status === StatusCodes.Forbidden
         }

--- a/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/util/errorhandling/AppExceptionHandlerSpec.scala
+++ b/payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/util/errorhandling/AppExceptionHandlerSpec.scala
@@ -1,6 +1,7 @@
 package jp.co.tis.lerna.payment.presentation.util.errorhandling
 
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.server.directives.MethodDirectives._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import jp.co.tis.lerna.payment.adapter.util.exception.BusinessException
@@ -19,7 +20,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new BusinessException(NotFound("userNm"))
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.NotFound
             contentType === `application/json(UTF-8)`
@@ -39,7 +40,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new BusinessException(ForbiddenFailure())
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.BadRequest
             contentType === `application/json(UTF-8)`
@@ -59,7 +60,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new BusinessException(ValidationFailure("injected failure"))
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.BadRequest
             contentType === `application/json(UTF-8)`
@@ -79,7 +80,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new BusinessException(IssuingServiceAlreadyCanceled())
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.BadRequest
             contentType === `application/json(UTF-8)`
@@ -99,7 +100,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new BusinessException(TimeOut("transactionNm"))
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.GatewayTimeout
             contentType === `application/json(UTF-8)`
@@ -119,7 +120,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new BusinessException(IssuingServiceUnavailable("transactionNm"))
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.ServiceUnavailable
             contentType === `application/json(UTF-8)`
@@ -139,7 +140,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new BusinessException(IssuingServiceServerError("transactionNm", "my-error-code"))
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.InternalServerError
             contentType === `application/json(UTF-8)`
@@ -159,7 +160,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new BusinessException(IssuingServiceBadRequestError("transactionNm"))
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.InternalServerError
             contentType === `application/json(UTF-8)`
@@ -179,7 +180,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new BusinessException(IssuingServiceTimeoutError("transactionNm"))
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.InternalServerError
             contentType === `application/json(UTF-8)`
@@ -199,7 +200,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new BusinessException(UnpredictableError())
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.InternalServerError
             contentType === `application/json(UTF-8)`
@@ -219,7 +220,7 @@ class AppExceptionHandlerSpec extends StandardSpec with ScalatestRouteTest with 
           throw new Error
         }
 
-        Get() ~> route ~> check {
+        Get() ~> Route.seal(route) ~> check {
           expect {
             status === StatusCodes.InternalServerError
           }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val lerna                    = "2.0.0-f8684d32-SNAPSHOT"
+    val lerna                    = "2.0.0-80f86b49-SNAPSHOT"
     val akka                     = "2.6.10"
     val akkaHttp                 = "10.1.12"
     val akkaPersistenceCassandra = "1.0.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   object Versions {
     val lerna                    = "2.0.0-80f86b49-SNAPSHOT"
     val akka                     = "2.6.10"
-    val akkaHttp                 = "10.1.12"
+    val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"
     val akkaProjection           = "1.1.0"
     val scalaTest                = "3.1.4"


### PR DESCRIPTION
## 参考
- [10.2.x Release Notes • Akka HTTP](https://doc.akka.io/docs/akka-http/current/release-notes/10.2.x.html)
- [Migration Guide to and within Akka HTTP 10.2.x • Akka HTTP](https://doc.akka.io/docs/akka-http/current/migration-guide/migration-guide-10.2.x.html)

## 関連
- https://github.com/lerna-stack/lerna-app-library/pull/33 ```Update akka-http to 10.2.4 by tksugimoto · Pull Request #33 · lerna-stack/lerna-app-library```
- https://github.com/lerna-stack/lerna-sample-payment-app/issues/29 ```implicit な RejectionHandler, ExceptionHandler が分かりづらい · Issue #29 · lerna-stack/lerna-sample-payment-app```
  - 元から存在する implicit の問題は別途対応する