### PR TITLE
refactor: 開発用に SSL の検証を無効化する設定 を削除

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,6 @@ lazy val `payment-app` = (project in file("."))
           Seq(
             // ローカル開発環境でのみ有効にしたい環境変数はここで指定する。
             "-Djp.co.tis.lerna.payment.server-mode=DEV",
-            "-Dakka.ssl-config.loose.disableHostnameVerification=true",
             """-Dlerna.util.encryption.base64-key="v5LCFG4V1CbJxxPg+WTd8w=="""",
             """-Dlerna.util.encryption.base64-iv="46A7peszgqN3q/ww4k8lWg=="""",
             "-Djp.co.tis.lerna.payment.presentation.util.api.default.BASE.active=on",


### PR DESCRIPTION
- 使用されていない機能だった (./start-app-1.sh での起動の場合)
- (独自Root証明書を信頼して)証明書の正規の検証を使用するべき
- 非推奨となっていたAPIを使用していた
- Akka HTTP 10.2 対応で非推奨のためcompileエラー
  - 関連: https://github.com/lerna-stack/lerna-sample-payment-app/pull/27 ```Update akka http 10.2 by tksugimoto · Pull Request #27 · lerna-stack/lerna-sample-payment-app```
- 開発環境用コードが本番環境でも動くのがあまりよくない