### PR TITLE
sbt scoverage 更新 (1.8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ TODO: sample の version 体系について検討
         - `/metrics/system-metrics/jvm-memory/heap/max`
 - `Scala 2.12.13` に更新しました
 - `sbt-wartremover 2.4.13` に更新しました
+- `sbt-scoverage 1.8.2` に更新しました
 - Akka typed 対応のため、 `PaymentActor` から `self` にメッセージを送る際の処理を変更しました
     - graceful shutdown 時のレイテンシが増加する可能性があります
 - Akka typed 対応のため、 `PaymentActor` からのレスポンスメッセージを変更しました

--- a/build.sbt
+++ b/build.sbt
@@ -445,4 +445,4 @@ fetchGitCommitHash := {
   "git rev-parse HEAD".!!.trim
 }
 
-addCommandAlias("take-test-coverage", "clean;coverage;test:compile;test;coverageReport;coverageAggregate;")
+addCommandAlias("take-test-coverage", "clean;coverage;test:compile;test;coverageAggregate;")

--- a/build.sbt
+++ b/build.sbt
@@ -397,7 +397,7 @@ lazy val wartremoverSettings = Def.settings(
 )
 
 lazy val coverageSettings = Def.settings(
-  coverageMinimum := 80,
+  coverageMinimumStmtTotal := 80,
   coverageFailOnMinimum := false,
   // You can exclude classes from being considered for coverage measurement by
   // providing semicolon-separated list of regular expressions.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
 
 addSbtPlugin("org.wartremover" % "sbt-wartremover-contrib" % "1.3.1")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
 
 addSbtPlugin("io.gatling" % "gatling-sbt" % "3.0.0")
 


### PR DESCRIPTION
sbt-scoverage を 1.5.1 から 1.8.2 に更新します。
[scoverage/sbt-scoverage: sbt plugin for scoverage](https://github.com/scoverage/sbt-scoverage)

sbt-scoverage 1.5.1 は Scala 2.13.0+ には未対応であり、
sbt-scoverage 1.6.0+ で Scala 2.13.0+ に対応されるためです。

## リリースノート

1.5.1 => 1.8.2 までのリリースノートは次のリンクから確認できます。

- [Release 1.6.0 · scoverage/sbt-scoverage](https://github.com/scoverage/sbt-scoverage/releases/tag/v1.6.0)
- [Release sbt-scoverage v1.7.0 · scoverage/sbt-scoverage](https://github.com/scoverage/sbt-scoverage/releases/tag/v1.7.0)
- [Release sbt-scoverage v1.7.1 · scoverage/sbt-scoverage](https://github.com/scoverage/sbt-scoverage/releases/tag/v1.7.1)
- [Release v1.7.2 · scoverage/sbt-scoverage](https://github.com/scoverage/sbt-scoverage/releases/tag/v1.7.2)
- [Release v1.7.3 · scoverage/sbt-scoverage](https://github.com/scoverage/sbt-scoverage/releases/tag/v1.7.3)
- [Release sbt-scoverage v1.8.0 · scoverage/sbt-scoverage](https://github.com/scoverage/sbt-scoverage/releases/tag/v1.8.0)
- [Release sbt-scoverage v1.8.1 · scoverage/sbt-scoverage](https://github.com/scoverage/sbt-scoverage/releases/tag/v1.8.1)
- [Release sbt-scoverage v1.8.2 · scoverage/sbt-scoverage](https://github.com/scoverage/sbt-scoverage/releases/tag/v1.8.2)

## 移行作業

- `sbt take-test-coverage` から `coverageReport` を削除します
  1.6.0 から `coverageAggregate` の前に `coverageReport` を呼び出す必要がなくなったためです
- `coverageMinimum` の代わりに `coverageMinimumStmtTotal` を使用します
  1.8.0 から `coverageMinimum` は非推奨になりました。
  代わりに同じ意味である `coverageMinimumStmtTotal` を使用できます。

## 関連
- fix https://github.com/lerna-stack/lerna-sample-payment-app/issues/35 ```カバレッジが取得できない · Issue #35 · lerna-stack/lerna-sample-payment-app```
- https://github.com/lerna-stack/lerna.g8/pull/12