### PR TITLE
lerna-app-library 2.0.0 に更新する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ TODO: sample の version 体系について検討
 - [README](README.md) に Management APIs の使用方法を記載しました
 
 ### CHANGED
-- `lerna-app-library-2.0.0-6bad8983-SNAPSHOT` に更新しました
+- `lerna-app-library-2.0.0` に更新しました
     - `lerna-management` の更新に伴い、
       次の2つの HTTP APIs は Long 値から Double 値を返すように変更します。
         - `/metrics/rmu/sales_detail/ec_house_money/number_of_singleton`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val lerna                    = "2.0.0-80f86b49-SNAPSHOT"
+    val lerna                    = "2.0.0"
     val akka                     = "2.6.10"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"


### PR DESCRIPTION
lerna-app-library 2.0.0 がリリースされました。2.0.0 に更新します。
[Release v2.0.0 · lerna-stack/lerna-app-library](https://github.com/lerna-stack/lerna-app-library/releases/tag/v2.0.0)

## テスト

念のため、アプリケーションサーバを起動し、README にある次の API が動いていることを確認しました。

```
$ curl \
  --silent --show-error --noproxy '*' \
  -H 'Authorization:Bearer dummy' -H 'Content-Type:application/json' -H 'X-Tenant-Id:example' \
  -X PUT \
  -d '{ "amount":600 }' \
  "http://127.0.0.1:9001/00/ec/settlements/000000000000000000000000000000000000002/$(date +%s%3N)/payment"

{"orderId":"1626413528933","walletShopId":"000000000000000000000000000000000000002"}
```