### PR TITLE
2021.7.0 リリース

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ payment-app に関する注目すべき変更はこのファイルで文書化�
 ## Unreleased
 
 
-TODO: sample の version 体系について検討
+## 2021.7.0
+Calender Versioning を採用します。
 
 ### ADDED
 - [README](README.md) に Management APIs の使用方法を記載しました
@@ -27,10 +28,10 @@ TODO: sample の version 体系について検討
     -  `Status.Failure(exception)` -> 専用クラス化
     - ※ Response, Event の互換性が崩れる
 
-## Version 1.1.0
+## 1.1.0
 - `Changed` Read Model Updater を分散実行しスループットを向上
     - ※ tag の形式と offset の 保存テーブルが変更になったため、切替前後のeventの処理に注意（切替前のEventに未処理が存在する場合、切替後の処理対象とならない）
 
-## Version 1.0.0
+## 1.0.0
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 payment-app に関する注目すべき変更はこのファイルで文書化されます。
 
 このファイルの書き方に関する推奨事項については、[Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) を確認してください。
+[Calendar Versioning — CalVer](https://calver.org/) `YYYY.MM.MICRO` を採用しています。
 
 ## Unreleased
 
 
-## 2021.7.0
-Calender Versioning を採用します。
+## v2021.7.0
 
 ### ADDED
 - [README](README.md) に Management APIs の使用方法を記載しました
@@ -28,10 +28,10 @@ Calender Versioning を採用します。
     -  `Status.Failure(exception)` -> 専用クラス化
     - ※ Response, Event の互換性が崩れる
 
-## 1.1.0
+## v1.1.0
 - `Changed` Read Model Updater を分散実行しスループットを向上
     - ※ tag の形式と offset の 保存テーブルが変更になったため、切替前後のeventの処理に注意（切替前のEventに未処理が存在する場合、切替後の処理対象とならない）
 
-## 1.0.0
+## v1.0.0
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ payment-app に関する注目すべき変更はこのファイルで文書化�
 ## Unreleased
 
 
-## v2021.7.0
+## [v2021.7.0] - 2021-7-16
+[v2021.7.0]: https://github.com/lerna-stack/lerna-sample-payment-app/compare/v1.1.0...v2021.7.0
 
 ### ADDED
 - [README](README.md) に Management APIs の使用方法を記載しました
@@ -28,10 +29,12 @@ payment-app に関する注目すべき変更はこのファイルで文書化�
     -  `Status.Failure(exception)` -> 専用クラス化
     - ※ Response, Event の互換性が崩れる
 
-## v1.1.0
+## [v1.1.0] - 2021-3-30
+[v1.1.0]: https://github.com/lerna-stack/lerna-sample-payment-app/compare/v1.0.0...v1.1.0
 - `Changed` Read Model Updater を分散実行しスループットを向上
     - ※ tag の形式と offset の 保存テーブルが変更になったため、切替前後のeventの処理に注意（切替前のEventに未処理が存在する場合、切替後の処理対象とならない）
 
-## v1.0.0
+## [v1.0.0] - 2020-12-23
+[v1.0.0]: https://github.com/lerna-stack/lerna-sample-payment-app/releases/tag/v1.0.0
 
 - Initial release

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val `payment-app` = (project in file("."))
     inThisBuild(
       List(
         organization := "jp.co.tis.lerna.payment",
-        version := "1.1.0",
+        version := "2021.7.0",
         scalaVersion := "2.13.6",
         scalacOptions ++= Seq(
           "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,6 @@ lazy val `payment-app` = (project in file("."))
         // forkプロセスのstdoutをこのプロセスのstdout,stderrをこのプロセスのstderrに転送する
         // デフォルトのLoggedOutputでは、airframeやkamonが標準エラーに出力するログが[error]とプリフィクスがつき、紛らわしいためです。
         outputStrategy := Some(StdoutOutput),
-        resolvers += Resolver.sonatypeRepo("snapshots"),
       ),
     ),
     //


### PR DESCRIPTION
2021.7.0 をリリースします。

## 確認済

### バージョン番号の変更漏れありません
  ```
  $ git grep -iF '1.1.0' -- ':!docker/'
  CHANGELOG.md:## 1.1.0
  project/Dependencies.scala:    val akkaProjection           = "1.1.0"
  ```

### SNAPSHOT jar を使用している箇所はありません

```
$ git grep -iF 'snapshot'
docker/cassandra/conf/cassandra.yaml:# Whether or not to take a snapshot before each compaction.  Be
docker/cassandra/conf/cassandra.yaml:# snapshots for you.  Mostly useful if you're paranoid when there
docker/cassandra/conf/cassandra.yaml:snapshot_before_compaction: false
docker/cassandra/conf/cassandra.yaml:# Whether or not a snapshot is taken of the data before keyspace truncation
docker/cassandra/conf/cassandra.yaml:auto_snapshot: true
docker/cassandra/conf/cassandra.yaml:# (This can be much longer, because unless auto_snapshot is disabled
docker/cassandra/conf/cassandra.yaml:# we need to flush first so we can snapshot before removing the data.)
docs/projects/application/マルチテナント化されたClusterShardingの実装ガイド.md:                .withSnapshotPluginId(snapshotPluginId)
docs/projects/application/マルチテナント化されたClusterShardingの実装ガイド.md:          .withSnapshotPluginId(setup.snapshotPluginId)
payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/ecpayment/issuing/actor/PaymentActor.scala:            .withSnapshotPluginId(setup.snapshotPluginId)
payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/util/health/HealthCheckApplicationImpl.scala:          .withSnapshotPluginId(snapshotPluginId)
payment-app/application/src/main/scala/jp/co/tis/lerna/payment/application/util/tenant/actor/MultiTenantPersistentSupport.scala:  final def snapshotPluginId: String                         = "akka.persistence.no-snapshot-store"
payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/management/mock/MetricsImplMock.scala:import kamon.metric.PeriodSnapshot
payment-app/presentation/src/test/scala/jp/co/tis/lerna/payment/presentation/management/mock/MetricsImplMock.scala:  override def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = ???
```

## TODO
- [x] 次の resolver を削除する
  `build.sbt:        resolvers += Resolver.sonatypeRepo("snapshots"),` 

## TODO (After merged)
- [ ] `main` ブランチから `v2021.7.0` タグを作成する