### PR TITLE
Release v2021.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ payment-app に関する注目すべき変更はこのファイルで文書化�
 
 ## Unreleased
 
+
+## [v2021.10.0] - 2021-10-22
+[v2021.10.0]: https://github.com/lerna-stack/lerna-sample-payment-app/compare/v2021.7.0...v2021.10.0
+
 ### CHANGED
 
 - lerna-app-library 2.0.0 から 3.0.0 に更新しました

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val `payment-app` = (project in file("."))
     inThisBuild(
       List(
         organization := "jp.co.tis.lerna.payment",
-        version := "2021.7.0",
+        version := "2021.10.0",
         scalaVersion := "2.13.6",
         scalacOptions ++= Seq(
           "-deprecation",


### PR DESCRIPTION
v2021.10.0 をリリースします。

旧バージョン番号(2021.7.0) は CHANGELOG のみに存在することを確認しました。
```
$ git grep -iF 2021.7.0
CHANGELOG.md:[v2021.10.0]: https://github.com/lerna-stack/lerna-sample-payment-app/compare/v2021.7.0...v2021.10.0
CHANGELOG.md:## [v2021.7.0] - 2021-7-16
CHANGELOG.md:[v2021.7.0]: https://github.com/lerna-stack/lerna-sample-payment-app/compare/v1.1.0...v2021.7.0
```

TODO
* [x] マージ後 v2021.10.0 のリリース&タグを作成する