### PR TITLE
Release v2022.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ payment-app に関する注目すべき変更はこのファイルで文書化�
 このファイルの書き方に関する推奨事項については、[Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) を確認してください。
 [Calendar Versioning — CalVer](https://calver.org/) `YYYY.MM.MICRO` を採用しています。
 
-## Unreleased
+## [Unreleased]
+[Unreleased]: https://github.com/lerna-stack/lerna-sample-payment-app/compare/v2022.3.0...main
+
+
+## [v2022.3.0] - 2022-3-25
+[v2022.3.0]: https://github.com/lerna-stack/lerna-sample-payment-app/compare/v2021.10.0...v2022.3.0
 
 ### CHANGED
 - lerna-app-library 3.0.0 から 3.0.0-6-ca3f2b2b-SNAPSHOT に更新しました

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ payment-app に関する注目すべき変更はこのファイルで文書化�
 [v2022.3.0]: https://github.com/lerna-stack/lerna-sample-payment-app/compare/v2021.10.0...v2022.3.0
 
 ### CHANGED
-- lerna-app-library 3.0.0 から 3.0.0-6-ca3f2b2b-SNAPSHOT に更新しました
+- lerna-app-library 3.0.0 から 3.0.1 に更新しました
 
 
 ## [v2021.10.0] - 2021-10-22

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,6 @@ import Dependencies._
 
 import scala.util.Try
 
-// TODO Remove this snapshot repo after stable version release
-ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
-
 lazy val `payment-app` = (project in file("."))
   .enablePlugins(JavaAppPackaging, JavaServerAppPackaging, RpmPlugin, SystemdPlugin)
   .aggregate(

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,6 @@ lazy val `payment-app` = (project in file("."))
     inThisBuild(
       List(
         organization := "jp.co.tis.lerna.payment",
-        version := "2021.10.0",
         scalaVersion := "2.13.6",
         scalacOptions ++= Seq(
           "-deprecation",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
 
   object Versions {
-    val lerna                    = "3.0.0-6-ca3f2b2b-SNAPSHOT"
+    val lerna                    = "3.0.1"
     val akka                     = "2.6.10"
     val akkaHttp                 = "10.2.4"
     val akkaPersistenceCassandra = "1.0.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
 addSbtPlugin("io.gatling" % "gatling-sbt" % "3.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.22")
+
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")


### PR DESCRIPTION
* lerna-app-library を v3.0.1 に更新します
* バージョン番号を git から動的に設定します
  [sbt-dynver](https://github.com/sbt/sbt-dynver) を使用します
* CHANGELOG に v2022.3.0 を記載します

## 動作確認
README に記載の次の API について、エラーが発生しないことを確認しました。
```
curl \
  --silent --show-error --noproxy '*' \
  -H 'Authorization:Bearer dummy' -H 'Content-Type:application/json' -H 'X-Tenant-Id:example' \
  -X PUT \
  -d '{ "amount":600 }' \
  "http://127.0.0.1:9001/00/ec/settlements/000000000000000000000000000000000000002/$(date +%s%3N)/payment"
```